### PR TITLE
Database (JSON) improvements

### DIFF
--- a/src/pdm/framework/Database.py
+++ b/src/pdm/framework/Database.py
@@ -31,8 +31,12 @@ class JSONTableEncoder(json.JSONEncoder):
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, JSONMixin):
-            return {column.name: getattr(obj, column.name)
-                    for column in obj.__table__.columns}
+            if hasattr(obj, '__json_fields__'):
+                return {attr_name: getattr(obj, attr_name)
+                        for attr_name in obj.__json_fields__}
+            else:
+                return {column.name: getattr(obj, column.name)
+                        for column in obj.__table__.columns}
         return super(JSONTableEncoder, self).default(obj)
 
 #pylint: disable=too-few-public-methods

--- a/src/pdm/framework/Database.py
+++ b/src/pdm/framework/Database.py
@@ -31,12 +31,9 @@ class JSONTableEncoder(json.JSONEncoder):
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, JSONMixin):
-            if hasattr(obj, '__json_fields__'):
-                return {attr_name: getattr(obj, attr_name)
-                        for attr_name in obj.__json_fields__}
-            else:
-                return {column.name: getattr(obj, column.name)
-                        for column in obj.__table__.columns}
+            cols = [column.name for column in obj.__table__.columns
+                                if column.name not in obj.__excluded_fields__]
+            return {column: getattr(obj, column) for column in cols}
         return super(JSONTableEncoder, self).default(obj)
 
 #pylint: disable=too-few-public-methods
@@ -47,6 +44,9 @@ class JSONMixin(object):
     A mixin class which provides basic serialisation
     for SQLAlchemy based table classes.
     """
+
+    # No fields excluded by default
+    __excluded_fields__ = []
 
     def json(self):
         """JSONify the table object."""

--- a/src/pdm/framework/FlaskWrapper.py
+++ b/src/pdm/framework/FlaskWrapper.py
@@ -9,7 +9,7 @@ import logging
 import functools
 
 from pdm.framework.Tokens import TokenService
-from pdm.framework.Database import MemSafeSQAlchemy
+from pdm.framework.Database import MemSafeSQAlchemy, JSONTableEncoder
 
 from flask import Flask, Response, current_app, request
 
@@ -83,7 +83,8 @@ def jsonify(obj):
         input type.
         Returns a Flask response object.
     """
-    return Response(json.dumps(obj), mimetype='application/json')
+    return Response(json.dumps(obj, cls=JSONTableEncoder),
+                    mimetype='application/json')
 
 #pylint: disable=too-few-public-methods
 class DBContainer(object):

--- a/test/pdm/framework/test_Database.py
+++ b/test/pdm/framework/test_Database.py
@@ -82,11 +82,19 @@ class TestDBJson(unittest.TestCase):
                           mock.Mock(), cls=JSONTableEncoder)
 
     def test_jsonFields(self):
-        """ A class with a __json_fields__ attr should only
+        """ A class with a __excluded_fields__ attr should not
             export the fields listed.
         """
         class TestCls(JSONMixin):
-            __json_fields__ = ('A', 'C')
+            # Fake SQAlchemy table structure
+            columns = (mock.Mock(), mock.Mock(), mock.Mock())
+            columns[0].name = 'A'
+            columns[1].name = 'B'
+            columns[2].name = 'C'
+            __table__ = mock.Mock()
+            __table__.columns = columns
+            # Try to exclude field B
+            __excluded_fields__ = ('B')
             A = "TestA"
             B = "TestB"
             C = 123

--- a/test/pdm/framework/test_Database.py
+++ b/test/pdm/framework/test_Database.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env
+""" Framework database object tests. """
+
+import mock
+import json
+import datetime
+import unittest
+
+from pdm.framework.Database import MemSafeSQAlchemy
+from pdm.framework.Database import JSONMixin, JSONTableEncoder
+
+
+class TestMemSafeSQAlchemy(unittest.TestCase):
+    """ Tests the MemSafeSQAlchemy driver. """
+
+    def driver_test_helper(self, drivername, dbname):
+        """ Calls the SQAlchemy driver hacks with the given
+            drivername and dbname, returns the configured options.
+        """
+        obj = MemSafeSQAlchemy()
+        app = mock.Mock()
+        info = mock.Mock()
+        info.drivername = drivername
+        info.database = dbname
+        options = {}
+        ret = obj.apply_driver_hacks(app, info, options)
+        self.assertEqual(app, ret)
+        self.assertEqual(app, obj.app)
+        self.assertEqual(info, obj.info)
+        self.assertEqual(options, obj.options)
+        return options
+
+    def test_driver_hacks(self):
+        """ Checks that the driver hacks
+            are correctly applied.
+        """
+        class SQAlchemyBase(object):
+            def apply_driver_hacks(self, app, info, options):
+                self.app = app
+                self.info = info
+                self.options = options
+                return app
+        patcher = mock.patch.object(MemSafeSQAlchemy, '__bases__', 
+                                    (SQAlchemyBase,))
+        patcher.start()
+        # Check that options are patched if a memory SQLite DB is used
+        opts = self.driver_test_helper('sqlite', None)
+        self.assertIn('connect_args', opts)
+        conn_args = opts['connect_args']
+        self.assertIn('check_same_thread', conn_args)
+        self.assertFalse(conn_args['check_same_thread'])
+        self.assertIn('poolclass', opts)
+        from sqlalchemy.pool import StaticPool
+        self.assertEqual(opts['poolclass'], StaticPool)
+        # Check that options are unchanged if conditions not met
+        opts = self.driver_test_helper('sqlite', 'test.db')
+        self.assertDictEqual(opts, {})
+        opts = self.driver_test_helper('otherdb', None)
+        self.assertDictEqual(opts, {})
+        # Test complete, stop the patcher
+        patcher.is_local = True
+        patcher.stop()
+
+class TestDBJson(unittest.TestCase):
+    """ Test database JSON methods. """
+
+    def test_plain(self):
+        """ Test that JSONTableEncoder works on plain objects,
+            including date-times.
+        """
+        my_time = datetime.datetime.now()
+        test_dict = {'A': 1, 'B': 2, 'C': my_time}
+        json_str = json.dumps(test_dict, cls=JSONTableEncoder)
+        output_dict = json.loads(json_str)
+        self.assertItemsEqual(test_dict.keys(), output_dict.keys())
+        self.assertEqual(test_dict['A'], output_dict['A'])
+        self.assertEqual(test_dict['B'], output_dict['B'])
+        self.assertEqual(my_time.isoformat(), output_dict['C'])
+        # Other objects should fall through to the default,
+        # which causes a TypeError
+        self.assertRaises(TypeError, json.dumps,
+                          mock.Mock(), cls=JSONTableEncoder)
+
+    def test_jsonFields(self):
+        """ A class with a __json_fields__ attr should only
+            export the fields listed.
+        """
+        class TestCls(JSONMixin):
+            __json_fields__ = ('A', 'C')
+            A = "TestA"
+            B = "TestB"
+            C = 123
+
+        obj = TestCls()
+        json_str = obj.json()
+        # Convert the json back to an object and check the fields
+        ret_obj = json.loads(json_str)
+        self.assertDictEqual({'A': 'TestA',
+                              'C': 123}, ret_obj)
+
+    def test_jsonTable(self):
+        """ Check that we can serialise an SQLAlchemy table class.
+        """
+        class TestCls(JSONMixin):
+            columns = (mock.Mock(), mock.Mock())
+            columns[0].name = 'A'
+            columns[1].name = 'B'
+            __table__ = mock.Mock()
+            __table__.columns = columns
+
+            def __init__(self, A, B):
+                self.A = A
+                self.B = B
+
+        obj = TestCls(A="Test123", B=321)
+        json_str = obj.json()
+        # Now do the reverse procedure
+        ret_obj = TestCls.from_json(json_str)
+        self.assertEqual("Test123", ret_obj.A)
+        self.assertEqual(321, ret_obj.B)


### PR DESCRIPTION
Allow database objects to be passed to jsonify.
Add a new (optional) attribute to database objects '__json_fields__' to limit which fields get converted to JSON when .json() or jsonify() is called.
Add test cases for all of the framework.Database classes.