### PR TITLE
Add test cases for Tokens module

### DIFF
--- a/src/pdm/framework/FlaskWrapper.py
+++ b/src/pdm/framework/FlaskWrapper.py
@@ -184,8 +184,11 @@ class FlaskServer(Flask):
                 client_dn = request.headers['Ssl-Client-S-Dn']
         if 'X-Token' in request.headers:
             raw_token = request.headers['X-Token']
-            res, token_value = current_app.token_svc.check(raw_token)
-            if res:
+            try:
+                token_value = current_app.token_svc.check(raw_token)
+            except ValueError:
+                # Token decoding failed, it is probably corrupt or has been
+                # tampered with.
                 return "403 Invalid Token", 403
             client_token = True
         # Now check request against policy

--- a/src/pdm/framework/Tokens.py
+++ b/src/pdm/framework/Tokens.py
@@ -39,13 +39,12 @@ class TokenService(object):
 
     def check(self, token):
         """ Checks a token has a valid signature.
-            Returns a tuple of (error, value)
-            error is a string describing the problem or None if everything
-            was fine. Value is the token value, if error == None.
+            Returns the token value. 
+            If the token is not valid, a ValueError will be raised.
         """
         try:
             res = self.__signer.loads(token)
-            return (None, res)
+            return res
         except:
             # TODO: More specific catch here
-            return ("Token Error", None)
+            raise ValueError("Token is invalid")

--- a/test/pdm/framework/test_Tokens.py
+++ b/test/pdm/framework/test_Tokens.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+""" Test cases for framework Token module. """
+
+import unittest
+
+from pdm.framework.Tokens import TokenService
+
+class TokenServiceTest(unittest.TestCase):
+    """ Test TokenService functions. """
+
+    def test_basic(self):
+        """ Test generating and recovering a token. """
+        svc = TokenService()
+        TEST_STR = "Hello World"
+        token = svc.issue(TEST_STR)
+        res = svc.check(token)
+        self.assertEqual(TEST_STR, res)
+        # Check bad token case
+        self.assertRaises(ValueError, svc.check, "BadToken")
+
+    def test_salt(self):
+        """ Check that setting the salt works. """
+        TEST_STR = "Salt Test"
+        svc1 = TokenService(key="FixedKey", salt="salt1")
+        token1 = svc1.issue(TEST_STR)
+        svc2 = TokenService(key="FixedKey", salt="salt2")
+        token2 = svc2.issue(TEST_STR)
+        self.assertNotEqual(token1, token2)
+        self.assertRaises(ValueError, svc1.check, token2)
+        self.assertRaises(ValueError, svc2.check, token1)
+        self.assertEqual(TEST_STR, svc1.check(token1))
+        self.assertEqual(TEST_STR, svc2.check(token2))
+
+    def test_key(self):
+        """ Check that different keys yield different results. """
+        TEST_STR = "Key Test"
+        svc1 = TokenService(key="KeyA")
+        token1 = svc1.issue(TEST_STR)
+        svc2 = TokenService(key="KeyB")
+        token2 = svc2.issue(TEST_STR)
+        self.assertNotEqual(token1, token2)
+        self.assertRaises(ValueError, svc1.check, token2)
+        self.assertRaises(ValueError, svc2.check, token1)
+        self.assertEqual(TEST_STR, svc1.check(token1))
+        self.assertEqual(TEST_STR, svc2.check(token2))
+
+    def test_inst(self):
+        """ Check that two instances with the same parameters
+            generate compatible tokens.
+        """
+        TEST_STR = "Inst Test"
+        params = ("KeyStr", "SaltStr")
+        svc1 = TokenService(*params)
+        token1 = svc1.issue(TEST_STR)
+        svc2 = TokenService(*params)
+        token2 = svc2.issue(TEST_STR)
+        # Tokens should be identical
+        self.assertEqual(token1, token2)
+        self.assertEqual(TEST_STR, svc1.check(token2))


### PR DESCRIPTION
Adds a proper set of tests for the framework Tokens module. Also changes the Token interface slightly so that verify errors throw exceptions rather than the weird tuple that was returned before.