### PR TITLE
Fix failure to sign certs after reload in X509CA

### DIFF
--- a/src/pdm/utils/X509.py
+++ b/src/pdm/utils/X509.py
@@ -272,7 +272,8 @@ class X509CA(object):
         # Store the newly loaded objects
         self.__cert = cert
         self.__key = key
-        self.__sign_key = EVP.PKey(key)
+        self.__sign_key = EVP.PKey()
+        self.__sign_key.assign_rsa(key)
         self.__serial = serial
 
     def clear(self):

--- a/test/pdm/utils/test_X509.py
+++ b/test/pdm/utils/test_X509.py
@@ -281,13 +281,17 @@ class TestX509CA(unittest.TestCase):
             self.assertTrue(self.__ca.ready())
             self.assertEqual(self.__ca.get_serial(), 44)
             self.assertEqual(self.__ca.get_dn(), TEST_DN)
-            # Finally, test the serial error handling
+            # Test the serial error handling
             self.assertRaises(ValueError, self.__ca.set_ca,
                               cert, key, -123, passphrase)
             self.assertRaises(ValueError, self.__ca.set_ca,
                               cert, key, 0, passphrase)
             self.assertRaises(ValueError, self.__ca.set_ca,
                               cert, key, 1, passphrase)
+            # Finally check that CA can issue a cert
+            # This checks that __sign_key has been reloaded correctly.
+            usercert, _ = self.__ca.gen_cert("C = ZZ, CN = Sign Test User", 2)
+            self.assertIn('BEGIN CERTIFICATE', usercert)
 
     def test_gen_cert(self):
         """ Check issuing a client certificate. """


### PR DESCRIPTION
I found that the CA code would fail to issue a cert if the CA cert was loaded from a PEM file: This was caused by improper initialisation of __sign_key, this patch fixes the problem and adds a regression test.