### PR TITLE
Disable default (methodless) rules for endpoints

### DIFF
--- a/etc/demo.auth
+++ b/etc/demo.auth
@@ -3,10 +3,12 @@
 [groups/demo]
 
 [auth/demo]
+# Matches GET method as not method specified
 /demo/api/v1.0/hello = "ALL"
-/demo/api/v1.0/turtles = "CERT"
 # Note that this rule also matches the ones ending with turtles/<int:tid>
 /demo/api/v1.0/turtles%GET = "ANY"
+/demo/api/v1.0/turtles%POST = "CERT"
+/demo/api/v1.0/turtles%DELETE = "CERT"
 
 /demo/api/v1.0/get_token = "ALL"
 /demo/api/v1.0/verify_token = "TOKEN"

--- a/etc/demo.auth
+++ b/etc/demo.auth
@@ -3,7 +3,7 @@
 [groups/demo]
 
 [auth/demo]
-# Matches GET method as not method specified
+# Matches GET method as no method specified
 /demo/api/v1.0/hello = "ALL"
 # Note that this rule also matches the ones ending with turtles/<int:tid>
 /demo/api/v1.0/turtles%GET = "ANY"


### PR DESCRIPTION
Originally you could write a security rule for all methods on an endpoint... Janusz demonstrated that it's too easy to do this for a simple GET endpoint, but later add something like DELETE and have it open to everyone without realising it.

This patch makes it so that anything other than GET must specify the method to be allowed.

I'll write a full spec of the config files (including the auth files) when we concentrate on the user documentation.