### PR TITLE
Run full demo server/client as part of the travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: python
 python:
     - "2.7"
 install: pip install tox-travis
-script: tox
+script: tox -e ALL

--- a/src/pdm/framework/RESTClient.py
+++ b/src/pdm/framework/RESTClient.py
@@ -3,7 +3,6 @@
 """
 
 import json
-import mock
 import requests
 
 from pdm.utils.config import ConfigSystem
@@ -109,6 +108,10 @@ class RESTClientTest(object):
                             the end of testing with patcher.stop().
                     client is a patched instance of target class.
         """
+        # We import mock here as TestClient is only meant for use in the tests
+        # If we import it globally, it'll break importing this module in
+        # production.
+        import mock
         # We patch away the base class of the target, replacing it with
         # RESTClientTest instead.
         patcher = mock.patch.object(target, '__bases__', (RESTClientTest, ))

--- a/test/bin/run_server_test.sh
+++ b/test/bin/run_server_test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Run the full DemoService test server & client
+# Expects to be run with CWD in top of repo.
+
+# Try to make sure everything gets killed on unexpected exit.
+trap 'if [ "x$(jobs -p)" != "x" ]; then kill $(jobs -p); fi' EXIT
+
+# Check the test CA is built
+if [ ! -d etc/certs ]; then
+  pushd etc
+  ./build_ca.sh
+  popd
+fi
+
+# Now start the server
+echo -e "\n***\nStarting Server...\n***\n" >&2
+python bin/test_server.py etc/demo.conf &
+SERVER_PID=$!
+# Wait a few seconds for server to start-up
+sleep 5
+
+# Run the client
+echo -e "\n***\nStarting Client...\n***\n" >&2
+RET=0
+python bin/test_demo.py etc/demo.conf
+if [ "$?" -ne "0" ]; then
+  echo -e "\n\nERROR: Test client finished with errors." >&2
+  RET=1
+else
+  echo -e "\n\nSUCCESS: Test client finished without errors." >&2
+fi
+
+# Shutdown server as gracefully as possible
+kill $SERVER_PID
+wait $SERVER_PID
+exit $RET
+

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,5 @@ commands=
 # Full stack test using demo server + client
 [testenv:full]
 basepython=python2.7
-# TODO: This shouldn't be required, or if it really is should be
-#       moved into setup.py requires
-deps=
-  mock
 commands=
   /bin/bash test/bin/run_server_test.sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
-envlist = py27
+envlist = unit
 
-[testenv]
+# Standard unit testing + coverage
+[testenv:unit]
+basepython=python2.7
 deps=
   mock
   pytest
@@ -11,3 +13,12 @@ commands=
   coverage run --source pdm -m py.test {posargs}
   coverage report -m --omit=*test*
 
+# Full stack test using demo server + client
+[testenv:full]
+basepython=python2.7
+# TODO: This shouldn't be required, or if it really is should be
+#       moved into setup.py requires
+deps=
+  mock
+commands=
+  /bin/bash test/bin/run_server_test.sh


### PR DESCRIPTION
This adds support for running the whole demo server & client as a system test along side the unit tests on travis.

I'm not sure we're actually using tox-travis any more, but I'll leave it in for now.