### PR TITLE
Add pylint as a test

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,9 @@
+[BASIC]
+
+# Add "db" to standard name list
+good-names=i,j,k,ex,Run,_,db
+
+# Allow variable names to start with capital
+# To only be used with Table class references
+variable-rgx=(([a-zA-Z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+

--- a/test/bin/run_pylint.sh
+++ b/test/bin/run_pylint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
+echo "travis_fold:start:pylint"
 pylint src/pdm | tee pylint.log
+echo "travis_fold:end:pylint"
 
 # Get the score (as an int)
 SCORE=`grep 'Your code has been rated at' pylint.log \

--- a/test/bin/run_pylint.sh
+++ b/test/bin/run_pylint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+pylint src/pdm | tee pylint.log
+
+# Get the score (as an int)
+SCORE=`grep 'Your code has been rated at' pylint.log \
+        | grep -oP '[-0-9]+' | head -n 1`
+rm -f pylint.log
+
+echo "Detected pylint score (int): ${SCORE}"
+if [ "${SCORE}" -lt "7" ]; then
+  echo "Pylint score is too low."
+  exit 1
+fi
+exit 0
+

--- a/test/bin/run_pylint.sh
+++ b/test/bin/run_pylint.sh
@@ -10,7 +10,7 @@ SCORE=`grep 'Your code has been rated at' pylint.log \
 rm -f pylint.log
 
 echo "Detected pylint score (int): ${SCORE}"
-if [ "${SCORE}" -lt "7" ]; then
+if [ "${SCORE}" -lt "8" ]; then
   echo "Pylint score is too low."
   exit 1
 fi

--- a/test/pdm/demo/test_DemoClient.py
+++ b/test/pdm/demo/test_DemoClient.py
@@ -13,7 +13,7 @@ class TestDemoClient(unittest.TestCase):
     def setUp(self):
         # Get an instance of DemoService to test against
         conf = { 'test_param': 1111 }
-        self.__service = FlaskServer(self.__name__)
+        self.__service = FlaskServer("pdm.demo.DemoService")
         self.__service.test_mode(DemoService, conf)
         self.__service.fake_auth("ALL")
         self.__test = self.__service.test_client()

--- a/test/pdm/demo/test_DemoService.py
+++ b/test/pdm/demo/test_DemoService.py
@@ -11,7 +11,7 @@ class TestDemoService(unittest.TestCase):
 
     def setUp(self):
         conf = { 'test_param': 1111 }
-        self.__service = FlaskServer(self.__name__)
+        self.__service = FlaskServer("pdm.demo.DemoService")
         self.__service.test_mode(DemoService, conf)
         self.__service.fake_auth("ALL")
         self.__test = self.__service.test_client()
@@ -21,7 +21,7 @@ class TestDemoService(unittest.TestCase):
             exists.
         """
         # Create a clean copy of the service
-        service = FlaskServer(self.__name__)
+        service = FlaskServer("pdm.demo.DemoService")
         service.test_mode(DemoService, None)
         service.build_db()
         # Add a single turtle to the table

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,9 @@ basepython=python2.7
 # Standard unit testing + coverage
 [testenv:unit]
 deps=
-  mock
-  pytest
-  coverage
+  mock==1.0.1
+  pytest==2.7.0
+  coverage==3.6
 commands=
   coverage erase
   coverage run --source pdm -m py.test {posargs}
@@ -24,7 +24,7 @@ commands=
 
 [testenv:lint]
 deps=
-  mock
-  pylint
+  mock==1.0.1
+  pylint==1.6.5
 commands=
   /bin/bash test/bin/run_pylint.sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,12 @@
 [tox]
 envlist = unit
 
+[testenv]
+# Inherited by other test environments
+basepython=python2.7
+
 # Standard unit testing + coverage
 [testenv:unit]
-basepython=python2.7
 deps=
   mock
   pytest
@@ -14,14 +17,14 @@ commands=
   coverage report -m --omit=*test*
 
 # Full stack test using demo server + client
+# Should run with nothing other than setup.py deps
 [testenv:full]
-basepython=python2.7
 commands=
   /bin/bash test/bin/run_server_test.sh
 
 [testenv:lint]
-basepython=python2.7
 deps=
+  mock
   pylint
 commands=
   /bin/bash test/bin/run_pylint.sh

--- a/tox.ini
+++ b/tox.ini
@@ -18,3 +18,10 @@ commands=
 basepython=python2.7
 commands=
   /bin/bash test/bin/run_server_test.sh
+
+[testenv:lint]
+basepython=python2.7
+deps=
+  pylint
+commands=
+  /bin/bash test/bin/run_pylint.sh


### PR DESCRIPTION
This adds a test environment for pylint, tidies the tox config up a little and pins the test versions to match the EL7 versions (as well as one fix for where __name__ isn't included in the old unittest.TestCase base class for some reason).

I'll probably raise the required pylint score up to 9 once the current code actually reaches that number (I'll do another batch of pylint fixes in the near future, perhaps once I've done more of the actual CredService code).