### PR TITLE
Make token_svc a public attribute of FlaskWrapper

### DIFF
--- a/src/pdm/framework/FlaskWrapper.py
+++ b/src/pdm/framework/FlaskWrapper.py
@@ -244,12 +244,12 @@ class FlaskServer(Flask):
         self.__startup_funcs = []
         self.__test_auth = None
         self.__logger = logger
-        self.__token_svc = TokenService(token_key, server_name)
+        self.token_svc = TokenService(token_key, server_name)
         with self.app_context():
             current_app.test_auth = self.__test_auth
             current_app.log = logger
             current_app.policy = {}
-            current_app.token_svc = self.__token_svc
+            current_app.token_svc = self.token_svc
 
     def enable_db(self, db_uri):
         """ Enables a database connection pool for this server.

--- a/test/pdm/demo/test_DemoService.py
+++ b/test/pdm/demo/test_DemoService.py
@@ -112,6 +112,9 @@ class TestDemoService(unittest.TestCase):
         assert(res.status_code == 200)
         assert(len(res.data) > 10)
         assert("." in res.data)
+        # Actually check token content
+        token_data = self.__service.token_svc.check(json.loads(res.data))
+        assert(token_data == "Hello")
 
     def test_verifyTokenGood(self):
         self.__service.fake_auth("TOKEN", "TTest")


### PR DESCRIPTION
This can be used for testing the contents of tokens returned from services (as now demonstrated in DemoService tests).