### PR TITLE
modify class RESTClientTest.__do_call(self, call_fn, uri, data=None) …

### DIFF
--- a/src/pdm/framework/RESTClient.py
+++ b/src/pdm/framework/RESTClient.py
@@ -142,7 +142,7 @@ class RESTClientTest(object):
         """
         full_uri = "%s/%s" % (self.__base, uri)
         res = call_fn(full_uri, data=json.dumps(data))
-        if res.status_code not in [200, 201]:
+        if res.status_code not in (200, 201):
             raise RuntimeError("Request failed with code %u" % \
                                res.status_code)
         if res.data:

--- a/src/pdm/framework/RESTClient.py
+++ b/src/pdm/framework/RESTClient.py
@@ -142,7 +142,7 @@ class RESTClientTest(object):
         """
         full_uri = "%s/%s" % (self.__base, uri)
         res = call_fn(full_uri, data=json.dumps(data))
-        if res.status_code != 200:
+        if res.status_code not in [200, 201]:
             raise RuntimeError("Request failed with code %u" % \
                                res.status_code)
         if res.data:

--- a/test/pdm/framework/test_RESTClient.py
+++ b/test/pdm/framework/test_RESTClient.py
@@ -274,6 +274,15 @@ class TestRESTClientTest(unittest.TestCase):
         ret = self.__client.get('file')
         self.assertDictEqual(ret, RET_DATA)
 
+    def test_no_errors(self):
+        """ Check that codes 200 and 201 don't cause an exception. """
+        for code in (200, 201):
+            res_obj = mock.Mock()
+            res_obj.status_code = code
+            res_obj.data = ""
+            self.__tc.get.return_value = res_obj
+            self.__client.get('file')
+
     def test_errors(self):
         """ Check that error codes raise exceptions. """
         res_obj = mock.Mock()


### PR DESCRIPTION
…so it considers both return codes 200 and 201 as OK