### PR TITLE
Fix test suite for real CentOS7 nodes

### DIFF
--- a/src/pdm/framework/WSGIServer.py
+++ b/src/pdm/framework/WSGIServer.py
@@ -45,13 +45,13 @@ class WSGIAuth(wsgi.WSGIResource):
         """
         dn_parts = []
         # E-mail is special as it joins on to CN
-        if hasattr(x509name, 'CN'):
-            if hasattr(x509name, 'emailAddress'):
+        if hasattr(x509name, 'CN') and x509name.CN:
+            if hasattr(x509name, 'emailAddress') and x509name.emailAddress:
                 dn_parts.append("CN=%s/emailAddress=%s" % \
                                 (x509name.CN, x509name.emailAddress))
             else:
                 dn_parts.append("CN=%s" % x509name.CN)
-        elif hasattr(x509name, 'emailAddress'):
+        elif hasattr(x509name, 'emailAddress') and x509name.emailAddress:
             dn_parts.append("emailAddress=%s" % x509name.emailAddress)
         # Now do other, more standard, parts...
         for field in ('OU', 'O', 'L', 'ST', 'C'):

--- a/test/pdm/cred/test_CredService.py
+++ b/test/pdm/cred/test_CredService.py
@@ -136,7 +136,8 @@ class test_CredService(unittest.TestCase):
         for cred in creds:
             if cred.cred_type == CredService.CRED_TYPE_X509:
                 found_x509 = True
-                x509_obj = X509.load_cert_string(cred.cred_pub)
+                cred_str= cred.cred_pub.encode('ascii','ignore')
+                x509_obj = X509.load_cert_string(cred_str)
                 user_serial = x509_obj.get_serial_number()
                 user_dn = X509Utils.x509name_to_str(x509_obj.get_subject())
                 templ_dn = "C = XX, OU = Test Users, CN = User_%u " % \


### PR DESCRIPTION
Sometimes x509name objects have the attributes for all parts of the DN, with missing ones set to None, other times they have the attributes missing completely (depending on the library version).

Older versions of M2Crypto are also less tolerant of unicode strings from the DB.