### PR TITLE
Fix multi-module testing

### DIFF
--- a/etc/build_ca.sh
+++ b/etc/build_ca.sh
@@ -22,5 +22,10 @@ openssl x509 -req -CA CA.crt -CAkey CA.key -CAcreateserial -days 365 -sha256 -in
 # Client Cert
 openssl genrsa -out client.key 2048
 openssl req -new -batch -key client.key -subj "${BASEDN}/CN=client user" -out client.csr
-openssl x509 -req -CA CA.crt -CAkey CA.key -CAcreateserial -days 365 -sha256 -in client.csr -extfile ../openssl.cnf -extensions SAN -out client.crt
+openssl x509 -req -CA CA.crt -CAkey CA.key -CAcreateserial -days 365 -sha256 -in client.csr -out client.crt
 
+# Root cert
+# For testing, allowed to do all operations
+openssl genrsa -out root.key 2048
+openssl req -new -batch -key client.key -subj "${BASEDN}/CN=root" -out root.csr
+openssl x509 -req -CA CA.crt -CAkey CA.key -CAcreateserial -days 365 -sha256 -in root.csr -out root.crt

--- a/etc/system.auth
+++ b/etc/system.auth
@@ -1,13 +1,23 @@
 # Demo application authentication
 
 [groups/endpoint]
+rw_func = ["CERT:C = XX, L = Default City, O = Default Company Ltd, OU = Test CA, CN = root"]
+ro_func = ["ALL"]
 
 [auth/endpoint]
-# None Yet!
+/endpoints/api/v1.0/site%GET = "@ro_func"
+/endpoints/api/v1.0/site%POST = "@rw_func"
+/endpoints/api/v1.0/site%DELETE = "@rw_func"
+/endpoints/api/v1.0/sitemap%GET = "@ro_func"
+/endpoints/api/v1.0/sitemap%POST = "@rw_func"
+/endpoints/api/v1.0/sitemap%DELETE = "@rw_func"
+
 
 [groups/cred]
-user_service = ["CERT:C = XX, L = Default City, O = Default Company Ltd, OU = Test CA, CN = localhost"]
-job_service = ["CERT:C = XX, L = Default City, O = Default Company Ltd, OU = Test CA, CN = localhost"]
+user_service = ["CERT:C = XX, L = Default City, O = Default Company Ltd, OU = Test CA, CN = localhost",
+                "CERT:C = XX, L = Default City, O = Default Company Ltd, OU = Test CA, CN = root"]
+job_service = ["CERT:C = XX, L = Default City, O = Default Company Ltd, OU = Test CA, CN = localhost",
+               "CERT:C = XX, L = Default City, O = Default Company Ltd, OU = Test CA, CN = root"]
 
 [auth/cred]
 /cred/api/v1.0/ca = "ALL"

--- a/src/pdm/cred/CredDB.py
+++ b/src/pdm/cred/CredDB.py
@@ -30,7 +30,6 @@ class CredDBModel(object):
             expiry_date = Column(TIMESTAMP, nullable=False)
             cred_pub = Column(TEXT, nullable=False)
             cred_priv = Column(TEXT, nullable=False)
-            sub_creds = relationship("JobCred", cascade="delete")
 
         #pylint: disable=too-few-public-methods, unused-variable
         class JobCred(db_base):
@@ -43,3 +42,5 @@ class CredDBModel(object):
             expiry_date = Column(TIMESTAMP, nullable=False)
             cred_pub = Column(TEXT, nullable=False)
             cred_priv = Column(TEXT, nullable=False)
+
+        UserCred.sub_creds = relationship(JobCred, cascade="delete")

--- a/src/pdm/demo/DemoService.py
+++ b/src/pdm/demo/DemoService.py
@@ -2,8 +2,9 @@
 """ A service for demonstrating FlaskWrapper. """
 
 import flask
-from flask import request
-from pdm.framework.FlaskWrapper import export, export_ext, startup, db_model, jsonify
+from flask import request, current_app
+from pdm.framework.FlaskWrapper import (export, export_ext, startup,
+                                        startup_test, db_model, jsonify)
 
 import pdm.demo.DemoDB
 
@@ -15,19 +16,25 @@ class DemoService(object):
     #pylint disable=invalid-name
     @staticmethod
     @startup
-    def preload_turtles(config):
+    def start_turtles(config):
         """ Configure the turtles application.
-            Creates an example database if DB is entry.
             Prints valud of "test_param" from the config.
         """
-        log = flask.current_app.log
+        log = current_app.log
         test_param = config.pop("test_param", 0)
         log.info("Hello Turtles (%u)", test_param)
-        db = flask.current_app.db
+
+    @staticmethod
+    @startup_test
+    def preload_turtles():
+        """ Creates an example database if DB is empty.
+        """
+        log = current_app.log
+        db = current_app.db
         Turtle = db.tables.Turtle
         num = db.session.query(Turtle).count()
         if num:
-            print "%u turtle(s) already exist." % num
+            log.info("%u turtle(s) already exist.", num)
             return
         # No turtles, add some...
         turtles = (Turtle(name='Timmy'),

--- a/src/pdm/endpoint/EndpointDB.py
+++ b/src/pdm/endpoint/EndpointDB.py
@@ -19,8 +19,6 @@ class EndpointDBModel(object):
             site_id = Column(Integer, primary_key=True)
             site_name = Column(TEXT, nullable=False, unique=True)
             site_desc = Column(TEXT, nullable=False)
-            endpoints = relationship("Endpoint", cascade="delete")
-            users = relationship("UserMap", cascade="delete")
 
         #pylint: disable=too-few-public-methods, unused-variable
         class Endpoint(db_base):
@@ -39,3 +37,6 @@ class EndpointDBModel(object):
             site_id = Column(Integer, ForeignKey(Site.site_id),
                              primary_key=True)
             username = Column(TEXT, nullable=False)
+
+        Site.endpoints = relationship(Endpoint, cascade="delete")
+        Site.users = relationship(UserMap, cascade="delete")

--- a/src/pdm/endpoint/EndpointService.py
+++ b/src/pdm/endpoint/EndpointService.py
@@ -2,10 +2,11 @@
 """ Site/Endpoint service module. """
 
 import json
-from flask import request
+from flask import current_app, request
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import FlushError
-from pdm.framework.FlaskWrapper import db_model, export_ext, jsonify
+from pdm.framework.FlaskWrapper import (db_model, export_ext, jsonify, \
+                                        startup_test)
 from pdm.endpoint.EndpointDB import EndpointDBModel
 from pdm.utils.db import managed_session
 
@@ -13,6 +14,38 @@ from pdm.utils.db import managed_session
 @db_model(EndpointDBModel)
 class EndpointService(object):
     """ Endpoint service. """
+
+    @staticmethod
+    @startup_test
+    def test_data():
+        """ Adds test data to the database.
+        """
+        db = current_app.db
+        Site = db.tables.Site
+        Endpoint = db.tables.Endpoint
+        entries = [
+            Site(site_id=1,
+                 site_name='Site1',
+                 site_desc='First Test Site'),
+            Site(site_id=2,
+                 site_name='Site2',
+                 site_desc='Second Test Site'),
+            Endpoint(ep_id=1,
+                     site_id=1,
+                     ep_uri='gsiftp://localhost/site1'),
+            Endpoint(ep_id=2,
+                     site_id=1,
+                     ep_uri='ssh://localhost/site1'),
+            Endpoint(ep_id=3,
+                     site_id=2,
+                     ep_uri='gsiftp://localhost/site2'),
+            Endpoint(ep_id=4,
+                     site_id=2,
+                     ep_uri='ssh://localhost/site2'),
+        ]
+        for entry in entries:
+            db.session.add(entry)
+        db.session.commit()
 
     @staticmethod
     @export_ext("site")

--- a/src/pdm/framework/FlaskWrapper.py
+++ b/src/pdm/framework/FlaskWrapper.py
@@ -369,7 +369,7 @@ class FlaskServer(Flask):
         with self.app_context():
             current_app.policy.update(real_rules)
 
-    def test_mode(self, main_cls, conf="", with_test=False):
+    def test_mode(self, main_cls, conf="", with_test=True):
         """ Configures this app instance in test mode.
             An in-memory Sqlite database is used for the DB.
             main_cls is the class to use for endpoints.

--- a/src/pdm/framework/Startup.py
+++ b/src/pdm/framework/Startup.py
@@ -109,7 +109,7 @@ class ExecutableServer(object):
         if all_config:
             # There are => Unused items = typos?
             keys = ', '.join(all_config.keys())
-            raise ValueError("Unused config params for %s: '%s'" % (app_name, keys))
+            raise ValueError("Unused config params: '%s'" % keys)
 
     def __init_wsgi(self, wsgi_name, config):
         """ Creates an instance of FlaskServer, opens a port and configures

--- a/test/bin/run_server_test.sh
+++ b/test/bin/run_server_test.sh
@@ -12,9 +12,9 @@ if [ ! -d etc/certs ]; then
   popd
 fi
 
-# Now start the server
+# Now start the server (in test mode)
 echo -e "\n***\nStarting Server...\n***\n" >&2
-python bin/test_server.py etc/demo.conf &
+python bin/test_server.py -t etc/demo.conf &
 SERVER_PID=$!
 # Wait a few seconds for server to start-up
 sleep 5

--- a/test/pdm/demo/test_DemoClient.py
+++ b/test/pdm/demo/test_DemoClient.py
@@ -14,7 +14,7 @@ class TestDemoClient(unittest.TestCase):
         # Get an instance of DemoService to test against
         conf = { 'test_param': 1111 }
         self.__service = FlaskServer("pdm.demo.DemoService")
-        self.__service.test_mode(DemoService, conf)
+        self.__service.test_mode(DemoService, conf, with_test=True)
         self.__service.fake_auth("ALL")
         self.__test = self.__service.test_client()
 

--- a/test/pdm/demo/test_DemoService.py
+++ b/test/pdm/demo/test_DemoService.py
@@ -12,7 +12,7 @@ class TestDemoService(unittest.TestCase):
     def setUp(self):
         conf = { 'test_param': 1111 }
         self.__service = FlaskServer("pdm.demo.DemoService")
-        self.__service.test_mode(DemoService, conf)
+        self.__service.test_mode(DemoService, conf, with_test=True)
         self.__service.fake_auth("ALL")
         self.__test = self.__service.test_client()
 
@@ -30,7 +30,7 @@ class TestDemoService(unittest.TestCase):
         db.session.add(new_turtle)
         db.session.commit()
         # Continue service start-up
-        service.before_startup({})
+        service.before_startup({}, with_test=True)
         service.fake_auth("ALL")
         client = service.test_client()
         # Now check that we only have one turtle

--- a/test/pdm/endpoint/test_EndpointClient.py
+++ b/test/pdm/endpoint/test_EndpointClient.py
@@ -12,7 +12,7 @@ class test_EndpointClient(unittest.TestCase):
 
     def setUp(self):
         self._service = FlaskServer("pdm.endpoint.EndpointService")
-        self._service.test_mode(EndpointService, {})
+        self._service.test_mode(EndpointService, {}, with_test=False)
         self._service.fake_auth("ALL")
         self._test = self._service.test_client()
         patcher, inst = RESTClientTest.patch_client(EndpointClient,

--- a/test/pdm/endpoint/test_EndpointService.py
+++ b/test/pdm/endpoint/test_EndpointService.py
@@ -10,28 +10,28 @@ from pdm.framework.FlaskWrapper import FlaskServer
 
 # Test data, prepopulated into the DB in setUp
 TEST_SITES = [
-    { 'site_id': 1, 'site_name': 'Test1', 'site_desc': 'Test Site 1' },
-    { 'site_id': 2, 'site_name': 'Test2', 'site_desc': 'Test Site 2' },
-    { 'site_id': 3, 'site_name': 'TestC', 'site_desc': 'Test Site C' },
-    { 'site_id': 4, 'site_name': 'Test4', 'site_desc': 'Test Site, No EPs' },
+    { 'site_id': 10, 'site_name': 'Test1', 'site_desc': 'Test Site 1' },
+    { 'site_id': 20, 'site_name': 'Test2', 'site_desc': 'Test Site 2' },
+    { 'site_id': 30, 'site_name': 'TestC', 'site_desc': 'Test Site C' },
+    { 'site_id': 40, 'site_name': 'Test4', 'site_desc': 'Test Site, No EPs' },
 ]
 TEST_EPS = [
-    { 'ep_id': 1, 'site_id': 1, 'ep_uri': 'https://localhost/1' },
-    { 'ep_id': 2, 'site_id': 1, 'ep_uri': 'https://localhost/1' },
-    { 'ep_id': 3, 'site_id': 1, 'ep_uri': 'https://localhost/blah' },
-    { 'ep_id': 4, 'site_id': 2, 'ep_uri': 'https://localhost/2' },
-    { 'ep_id': 5, 'site_id': 2, 'ep_uri': 'https://localhost/2' },
-    { 'ep_id': 6, 'site_id': 3, 'ep_uri': 'https://localhost/../' },
-    { 'ep_id': 7, 'site_id': 3, 'ep_uri': 'http://localhost/insecure' },
+    { 'ep_id': 10, 'site_id': 10, 'ep_uri': 'https://localhost/1' },
+    { 'ep_id': 20, 'site_id': 10, 'ep_uri': 'https://localhost/1' },
+    { 'ep_id': 30, 'site_id': 10, 'ep_uri': 'https://localhost/blah' },
+    { 'ep_id': 40, 'site_id': 20, 'ep_uri': 'https://localhost/2' },
+    { 'ep_id': 50, 'site_id': 20, 'ep_uri': 'https://localhost/2' },
+    { 'ep_id': 60, 'site_id': 30, 'ep_uri': 'https://localhost/../' },
+    { 'ep_id': 70, 'site_id': 30, 'ep_uri': 'http://localhost/insecure' },
 ]
 TEST_MAPPINGS = [
-    { 'site_id': 1, 'user_id': 10, 'username': 'user001' },
-    { 'site_id': 1, 'user_id': 20, 'username': 'turtle' },
-    { 'site_id': 2, 'user_id': 30, 'username': 'timmy' },
-    { 'site_id': 2, 'user_id': 40, 'username': 'jimmy' },
-    { 'site_id': 4, 'user_id': 50, 'username': 'longusername' },
-    { 'site_id': 4, 'user_id': 60, 'username': 'bill' },
-    { 'site_id': 4, 'user_id':  4, 'username': 'gates' },
+    { 'site_id': 10, 'user_id': 10, 'username': 'user001' },
+    { 'site_id': 10, 'user_id': 20, 'username': 'turtle' },
+    { 'site_id': 20, 'user_id': 30, 'username': 'timmy' },
+    { 'site_id': 20, 'user_id': 40, 'username': 'jimmy' },
+    { 'site_id': 40, 'user_id': 50, 'username': 'longusername' },
+    { 'site_id': 40, 'user_id': 60, 'username': 'bill' },
+    { 'site_id': 40, 'user_id':  4, 'username': 'gates' },
 ]
 
 class test_EndpointService(unittest.TestCase):
@@ -82,7 +82,8 @@ class test_EndpointService(unittest.TestCase):
         res = self.__client.get('/endpoints/api/v1.0/site')
         self.assertEqual(res.status_code, 200)
         site_list = json.loads(res.data)
-        self.assertEqual(len(site_list), len(TEST_SITES) + 1)
+        # Check length, but there may be other test data
+        self.assertGreaterEqual(len(site_list), len(TEST_SITES) + 1)
         # Most recently added site should be the last one
         site_out = site_list[-1]
         self.assertIn('site_id', site_out)
@@ -156,13 +157,13 @@ class test_EndpointService(unittest.TestCase):
         TEST_URI = "gsiftp://test_host/test"
         data = {'ep_uri': TEST_URI}
         json_data = json.dumps(data)
-        # Try adding another endpoint to site 1.
-        res = self.__client.post('endpoints/api/v1.0/site/1', data=json_data)
+        # Try adding another endpoint to site 10.
+        res = self.__client.post('endpoints/api/v1.0/site/10', data=json_data)
         self.assertEqual(res.status_code, 200)
         # Check we got an ID number back
         ep_id = json.loads(res.data)
         self.assertIsInstance(ep_id, int)
-        res = self.__client.get('endpoints/api/v1.0/site/1')
+        res = self.__client.get('endpoints/api/v1.0/site/10')
         self.assertEqual(res.status_code, 200)
         site_info = json.loads(res.data)
         # Check the site_info matches site 1 from the test data.


### PR DESCRIPTION
This adds quite a few things:
 * Support for starting multiple modules within one service.
 * Support for test data (-t option to demo_server.py).
 * Root certificate who can do anything on any service (at least in theory, they still need special rules in .auth, there isn't any backdoor in the code for this :-)

Hopefully that's enough to enable one module to be tested against another... You start the both services up together giving the -t option to demo_server.py and then use any client (curl, a custom python client, Janusz's CLI once it exists) to poke things.

Regards,
Simon