### PR TITLE
ignore test.db file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ etc/certs
 # Editor lock files
 *.swp
 *~
+
+# Test DB location
+test.db


### PR DESCRIPTION
As we improve the testing, we will probably eventually want a persistent database... This patch simply ignores that most likely location of that file in the git client.