### PR TITLE
Make RESTClientTest Inherit from RESTClient

### DIFF
--- a/src/pdm/framework/RESTClient.py
+++ b/src/pdm/framework/RESTClient.py
@@ -108,7 +108,7 @@ class RESTClient(object):
         return self.__do_request(uri, 'DELETE')
 
 
-class RESTClientTest(object):
+class RESTClientTest(RESTClient):
     """ A mock version of RESTClient which calls a local
         Flask test_client instance instead.
         Useful for doing unit testing, use patch_client to get


### PR DESCRIPTION
Conceptually `RESTClientTest` is a `RESTClient`, just one intended for testing. This means that `isinstance(obj, RESTClient)` type checks will pass with `RESTClientTest`. More importantly for me anyway ;-) while the super call in the `__init__` is sufficient for most client testing, if like in `workqueue.Worker` you have multiple inheritance you may want to call the `__init__` directly rather than use some horrible super fudge with variable args passing around. In this case it currently fails to initialise as the base (`RESTClientTest`) is not a `RESTClient`. This passes all my local workqueue testing, lets see what Travis makes of it.