### PR TITLE
Better rest client errors

### DIFF
--- a/test/pdm/framework/test_RESTClient.py
+++ b/test/pdm/framework/test_RESTClient.py
@@ -6,7 +6,7 @@ import mock
 import unittest
 import functools
 
-from pdm.framework.RESTClient import RESTClient, RESTClientTest
+from pdm.framework.RESTClient import RESTClient, RESTClientTest, RESTException
 
 class TestRESTClient(unittest.TestCase):
     """ Test the RESTClient class. """
@@ -112,7 +112,7 @@ class TestRESTClient(unittest.TestCase):
         """
         client = self.__get_inst()
         self.__mock_req(mock_req, 500, "")
-        self.assertRaises(RuntimeError, client.get, '/test_url')
+        self.assertRaises(RESTException, client.get, '/test_url')
 
     @mock.patch("pdm.framework.RESTClient.requests")
     def test_token(self, mock_req):
@@ -314,4 +314,15 @@ class TestRESTClientTest(unittest.TestCase):
         res_obj.status_code = 500
         res_obj.data = ""
         self.__tc.get.return_value = res_obj
-        self.assertRaises(RuntimeError, self.__client.get, 'file')
+        self.assertRaises(RESTException, self.__client.get, 'file')
+
+    def test_rest_exception(self):
+        """ Check basic RESTException functionality. """
+        res_obj = mock.Mock()
+        res_obj.status_code = 500
+        res_obj.data = "Something Went Wrong"
+        self.__tc.get.return_value = res_obj
+        with self.assertRaises(RESTException) as err:
+            self.__client.get('file')
+        self.assertEqual(err.exception.code, res_obj.status_code)
+        self.assertIn(res_obj.data, err.exception.message)

--- a/test/pdm/userservicedesk/test_HRClient.py
+++ b/test/pdm/userservicedesk/test_HRClient.py
@@ -63,7 +63,7 @@ class TestHRClient(unittest.TestCase):
             res = self.__client.login('Johnny@example.com', 'very_secret1')
 
         the_exception = login_ex.exception
-        assert (the_exception[0] == 'Request failed with code 403')
+        assert (the_exception.code == 403)
 
     def test_add_user(self):
         userdict = {
@@ -78,7 +78,7 @@ class TestHRClient(unittest.TestCase):
             res = self.__client.add_user(userdict)
 
         the_exception = add_ex.exception
-        assert (the_exception[0] == 'Request failed with code 403')
+        assert (the_exception.code == 403)
 
     def test_change_password(self):
         self.__service.fake_auth("TOKEN", {'id':1, 'expiry':None, 'key': 'unused'})
@@ -91,7 +91,7 @@ class TestHRClient(unittest.TestCase):
             res = self.__client.change_password('newpassword', None)
 
         the_exception = pwd_ex.exception
-        assert (the_exception[0] == 'Request failed with code 400')
+        assert (the_exception.code == 400)
 
     def test_get_user(self):
         self.__service.fake_auth("TOKEN", {'id':1, 'expiry':None, 'key': 'unused'})


### PR DESCRIPTION
Adds an exception class that will allow clients to easily get the error code + message (while still being backwards compatible with old code).

Closes #76.