### PR TITLE
Refactor and improve ACL code

### DIFF
--- a/bin/test_demo.py
+++ b/bin/test_demo.py
@@ -15,6 +15,8 @@ def show_turtles(client):
 
 def main():
 
+    return_code = 0
+
     if len(sys.argv) != 2:
         print "Usage: test_demo.py <conf_file>"
         sys.exit(1)
@@ -53,6 +55,7 @@ def main():
     try:
         res = client.get('verify_token')
         print "Tokenless request accepted!!! %s" % res
+        return_code += 1
     except:
         print "No token request rejected as expected. :-)"
   
@@ -61,6 +64,7 @@ def main():
         client.set_token('WRONGTOKEN')
         res = client.get('verify_token')
         print "Invalid token accepted!!! %s" % res
+        return_code += 1
     except:
         print "Wrong token rejected, as expected. :-)"
 
@@ -68,6 +72,8 @@ def main():
     client.set_token(token)
     res = client.get('verify_token')
     print "Verify real token: %s" % res
+
+    sys.exit(return_code)
 
 
 if __name__ == '__main__':

--- a/etc/demo.auth
+++ b/etc/demo.auth
@@ -6,11 +6,10 @@
 /web/* = "ALL"
 # Matches GET method as no method specified
 /demo/api/v1.0/hello = "ALL"
-# Note that this rule also matches the ones ending with turtles/<int:tid>
-/demo/api/v1.0/turtles%GET = "ANY"
+/demo/api/v1.0/turtles%GET = "CERT"
 /demo/api/v1.0/turtles%POST = "CERT"
-/demo/api/v1.0/turtles%DELETE = "CERT"
-/demo/api/v1.0/turtles%PUT = "CERT"
+/demo/api/v1.0/turtles/?%DELETE = "CERT"
+/demo/api/v1.0/turtles/?%PUT = "CERT"
 
 /demo/api/v1.0/get_token = "ALL"
 /demo/api/v1.0/verify_token = "TOKEN"

--- a/etc/system.auth
+++ b/etc/system.auth
@@ -13,37 +13,71 @@ worker = ["CERT:C=XX, L=Default City, O=Default Company Ltd, OU=Test CA, CN=work
 /web/listings%POST = "ALL"
 
 [auth/users]
-/users/api/v1.0/users%GET = "@user"
-/users/api/v1.0/users%PUT = "@user"
+# Add user
 /users/api/v1.0/users%POST = "ALL"
+# Get user info
 /users/api/v1.0/users/self%GET = "@user"
+# Delete user
 /users/api/v1.0/users/self%DELETE = "@user"
+# Change user password
 /users/api/v1.0/passwd%PUT = "@user"
+# Login as user
 /users/api/v1.0/login%POST = "ALL"
-/users/api/v1.0/verify_token = "@user"
 
 [auth/cred]
+# Get CA cert
 /cred/api/v1.0/ca = "ALL"
-/cred/api/v1.0/user%GET = "@system"
+# Generate user cred
 /cred/api/v1.0/user%POST = "@system"
-/cred/api/v1.0/user%DELETE = "@system"
-/cred/api/v1.0/cred%GET = "@worker"
+# Get user cred info
+/cred/api/v1.0/user/?%GET = "@system"
+# Delete user creds
+/cred/api/v1.0/user/?%DELETE = "@system"
+# Generate proxy cred
 /cred/api/v1.0/cred%POST = "@user"
-/cred/api/v1.0/cred%DELETE = "@system"
+# Get proxy cred
+/cred/api/v1.0/cred/?%GET = "@worker"
+# Delete proxy cred
+/cred/api/v1.0/cred/?%DELETE = "@system"
 
 [auth/endpoint]
+# Get site list
 /endpoint/api/v1.0/site = "ALL"
+# Get site info (endpoints)
+/endpoint/api/v1.0/site/? = "ALL"
+# Add site
 /endpoint/api/v1.0/site%POST = "@system"
-/endpoint/api/v1.0/site%DELETE = "@system"
-/endpoint/api/v1.0/sitemap%GET = "@system"
-/endpoint/api/v1.0/sitemap%POST = "@system"
-/endpoint/api/v1.0/sitemap%DELETE = "@system"
+# Add endpoint
+/endpoint/api/v1.0/site/?%POST = "@system"
+# Delete site
+/endpoint/api/v1.0/site/?%DELETE = "@system"
+# Delete endpoint
+/endpoint/api/v1.0/site/?/?%DELETE = "@system"
+# Get mapping for site
+/endpoint/api/v1.0/sitemap/?%GET = "@system"
+# Add mapping for site
+/endpoint/api/v1.0/sitemap/?%POST = "@system"
+# Delete mappings
+/endpoint/api/v1.0/sitemap/?/?%DELETE = "@system"
 
 [auth/workqueue]
+# Get all jobs for the current user
 /workqueue/api/v1.0/jobs%GET = "@user"
+# Get details of a specific job ID
+/workqueue/api/v1.0/jobs/?%GET = "@user"
+# Get output for a specific job
+/workqueue/api/v1.0/jobs/?/output%GET = "@user"
+# Get status of a specific job
+/workqueue/api/v1.0/jobs/?/status%GET = "@user"
+# Add a job to the database
 /workqueue/api/v1.0/jobs%POST = "@user"
+# Add a list job
 /workqueue/api/v1.0/list%POST = "@user"
+# Add a copy job
 /workqueue/api/v1.0/copy%POST = "@user"
+# Add a remove job
 /workqueue/api/v1.0/remove%POST = "@user"
+# Get the next available job meeting criteria
 /workqueue/api/v1.0/worker%POST = "@worker"
-/workqueue/api/v1.0/worker%PUT = "@worker"
+# Return job status information
+/workqueue/api/v1.0/worker/?%PUT = "@worker"

--- a/src/pdm/cred/CredService.py
+++ b/src/pdm/cred/CredService.py
@@ -51,7 +51,10 @@ class CredService(object):
                 raise RuntimeError("%s parameter missing from config file." \
                                        % conf_key)
             current_app.ca_config[conf_key] = config.pop(conf_key)
-        # TODO: Normalise DNs into RFC format here!
+        # Normalise DNs into RFC format
+        for conf_key in ('ca_dn', 'user_dn_base'):
+            raw_dn = current_app.ca_config[conf_key]
+            current_app.ca_config[conf_key] = X509Utils.normalise_dn(raw_dn)
         # Then do optional parameters with defaults
         current_app.ca_config['ca_days'] = config.pop('ca_days', 3650)
         current_app.ca_config['user_max_days'] = \

--- a/src/pdm/framework/ACLManager.py
+++ b/src/pdm/framework/ACLManager.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
+""" Access Control for Flask Wrapper. """
 
-from flask import current_app, request
+from copy import deepcopy
+from flask import abort, current_app, request
+from pdm.utils.X509 import X509Utils
 
 
 class ACLManager(object):
@@ -24,18 +27,54 @@ class ACLManager(object):
         self.__groups = {}
         self.__rules = {}
 
+    def __check_entry(self, entry, allow_group):
+        """ Checks an entry is in a valid format and expands groups.
+            If groups are allowed, then inputting a group entry will
+            result in the expanded group entries on the output.
+            entry - The entry string to check.
+            allow_group - Boolean, on whether to allow group names.
+            Raises a ValueError if it isn't valid.
+            Returns a list of entries.
+            Each returned entry is a tuple of (auth_mode, auth_data).
+        """
+        if entry == "TOKEN":
+            return [(ACLManager.AUTH_MODE_TOKEN, None)]
+        elif entry == "CERT":
+            return [(ACLManager.AUTH_MODE_X509, None)]
+        elif entry == "ALL":
+            return [(ACLManager.AUTH_MODE_ALLOW_ALL, None)]
+        elif entry.startswith("CERT:"):
+            raw_dn = entry.split(':', 1)[1]
+            return [(ACLManager.AUTH_MODE_X509,
+                     X509Utils.normalise_dn(raw_dn))]
+        elif allow_group and entry.startswith("@"):
+            group_name = entry[1:]
+            if not group_name in self.__groups:
+                raise ValueError("Unrecognised group used in ACL rule: %s" % \
+                                 group_name)
+            return deepcopy(self.__groups[group_name])
+        raise ValueError("Invalid auth entry '%s'." % entry)
+
     def add_group_entry(self, group_name, entry):
         """ Adds an entry to a group, if the group doesn't exist it will be
             created, otherwise it will be appeneded. Note that groups can't
             currently be nested.
         """
-        pass
+        entries = self.__check_entry(entry, False)
+        if not group_name in self.__groups:
+            self.__groups[group_name] = entries
+        else:
+            self.__groups[group_name].extend(entries)
 
     def add_rule(self, res_path, entry):
         """ Adds a rule for a specific resource path. The entry can either
             be an existing group or a normal entry value.
         """
-        pass
+        if not '%' in res_path:
+            res_path = "%s%%GET" % res_path
+        if res_path in self.__rules:
+            raise ValueError("Duplicate auth rule for path '%s'." % res_path)
+        self.__rules[res_path] = self.__check_entry(entry, True)
 
     def test_mode(self, auth_mode, auth_data=None):
         """ Enabled test mode, where the authentication info is pre-set for
@@ -46,12 +85,16 @@ class ACLManager(object):
 
     @staticmethod
     def __get_real_request_auth():
+        """ Fills the details of the presented credentials into the
+            request object.
+        """
         # Cert auth
         if 'Ssl-Client-Verify' in request.headers \
             and 'Ssl-Client-S-Dn' in request.headers:
             # Request has client cert
             if request.headers['Ssl-Client-Verify'] == 'SUCCESS':
-                request.dn = request.headers['Ssl-Client-S-Dn']
+                raw_dn = request.headers['Ssl-Client-S-Dn']
+                request.dn = X509Utils.normalise_dn(raw_dn)
         # Token Auth
         if 'X-Token' in request.headers:
             raw_token = request.headers['X-Token']
@@ -67,20 +110,122 @@ class ACLManager(object):
                 return "403 Invalid Token", 403
 
     def __get_fake_request_auth(self):
+        """ Fills the request object with te test (fake) authentication
+            details.
+        """
         if self.__test_mode == ACLManager.AUTH_MODE_X509:
-            request.dn = self.__test_data
+            request.dn = X509Utils.normalise_dn(self.__test_data)
         elif self.__test_mode == ACLManager.AUTH_MODE_TOKEN:
             request.token = self.__test_data
             request.token_ok = True
+
+    @staticmethod
+    def __matches_rules(rules):
+        """ Checks the current request against a list of expanded rules.
+            If the request matches any of the rules, True is returned.
+            False is returned if no rules match the current request creds.
+        """
+        for rule in rules:
+            rule_mode, rule_data = rule
+            if rule_mode == ACLManager.AUTH_MODE_TOKEN:
+                if request.token_ok:
+                    return True
+                continue
+            elif rule_mode == ACLManager.AUTH_MODE_X509:
+                if rule_data is not None:
+                    if rule_data == request.dn:
+                        return True
+                else:
+                    if request.dn:
+                        return True
+                continue
+            elif rule_mode == ACLManager.AUTH_MODE_ALLOW_ALL:
+                return True
+        return False
+
+    @staticmethod
+    def __match_path(req_detail, rule_detail):
+        """ Checks whether a request path matches a rule path.
+            The rule path can contiain wildcards * or ?.
+            Although the * wildcard can only be in the last position.
+            Returns True if the rule_detail pattern matches req_detail.
+        """
+        req_path, req_method = req_detail.split('%')
+        rule_path, rule_method = rule_detail.split('%')
+        if req_method != rule_method:
+            return False # Wrong method
+        req_parts = req_path.split('/')
+        rule_parts = rule_path.split('/')
+        # If the request path is shorter than the rule, then it
+        # can't possibly match
+        if len(req_parts) < len(rule_parts):
+            return False
+        # If the rule ends in a wildcard, ignore all bits of the
+        # request path that match the wildcard
+        if rule_parts[-1] == '*':
+            req_parts = req_parts[0:len(rule_parts)]
+        # Now check each segment of the path to match either
+        # directly or by wildcard
+        for part_num in xrange(0, len(rule_parts)):
+            req_part = req_parts[part_num]
+            rule_part = rule_parts[part_num]
+            if rule_part == '?':
+                continue
+            if req_part != rule_part:
+                return False
+        # Everything matched, so the rule matches the request
+        return True
+
+    def __check_acl(self):
+        """ Checks the request object authentication details against the ACL
+            list for the requested resource.
+            Raises a Flask 403 abort if access should be denied.
+        """
+        # Work out the request URI
+        real_path = request.path
+        # Strip a trailing slash, as long as it isn't the only char
+        if real_path.endswith('/') and len(real_path) > 1:
+            real_path = real_path[:-1]
+        real_path = "%s%%%s" % (real_path, request.method)
+        # Now check the auth rules for this path
+        if real_path in self.__rules:
+            if self.__matches_rules(self.__rules[real_path]):
+                # The request matches => Access allowed
+                return
+            self.__log.info("Request %s denied (Failed to match specific rule).",
+                            request.uuid)
+            abort(403)
+        # No specific rule for this path, try generic rules
+        did_match = False
+        for rule_path in self.__rules.iterkeys():
+            if self.__match_path(real_path, rule_path):
+                did_match = True
+                if self.__matches_rules(self.__rules[rule_path]):
+                    # Access allowed via a generic rule
+                    return
+        reason = "no matching auth rule"
+        if did_match:
+            reason = "all wildcard rules denied access"
+        # No rule matches => request denied
+        self.__log.info("Request %s denied (%s).",
+                        request.uuid, reason)
+        abort(403)
 
     def check_request(self):
         """ Gets the current flask request object and checks it against the
             configured rule set.
         """
+        # We use '%' to seperate out the method from the rest of the request
+        # We simply don't support requests that contain a % in the URI from
+        # the client.
+        if '%' in request.path:
+            abort(404)
         request.dn = None
         request.token = None
         request.token_ok = False
         if self.__test_mode == ACLManager.AUTH_MODE_NONE:
             self.__get_real_request_auth()
+            self.__check_acl()
         else:
             self.__get_fake_request_auth()
+            # ACLs aren't actually checked in test mode

--- a/src/pdm/framework/ACLManager.py
+++ b/src/pdm/framework/ACLManager.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+class ACLManager(object):
+    """ Access Control List manager for Flask Wrapper.
+        Keeps a list of users who are allowed to access resources
+        and allows or rejects request based on the presented credentials.
+    """
+
+    AUTH_MODE_NONE = 0
+    AUTH_MODE_X509 = 1
+    AUTH_MODE_TOKEN = 2
+    AUTH_MODE_ALLOW_ALL = 3
+
+    def __init__(self, logger):
+        """ Create an empty instance of ACLManager (no predfined groups or
+            rules. Test mode is disabled by default.
+        """
+        self.__log = logger
+        self.__test_mode = ACLManager.AUTH_MODE_NONE
+        self.__test_data = None
+        self.__groups = {}
+        self.__rules = {}
+
+    def add_group_entry(self, group_name, entry):
+        """ Adds an entry to a group, if the group doesn't exist it will be
+            created, otherwise it will be appeneded. Note that groups can't
+            currently be nested.
+        """
+        pass
+
+    def add_rule(self, res_path, entry):
+        """ Adds a rule for a specific resource path. The entry can either
+            be an existing group or a normal entry value.
+        """
+        pass
+
+    def test_mode(self, auth_mode, auth_data=None):
+        """ Enabled test mode, where the authentication info is pre-set for
+            all requests. This should not be used in production.
+        """
+        pass
+
+    def dump_debug(self):
+        """ Dumps the configuration of the ACLManager to the logger
+            at the debug level. This includes all group and rule configuration.
+        """
+        pass
+
+    def check_request(self):
+        """ Gets the current flask request object and checks it against the
+            configured rule set.
+        """
+        pass
+

--- a/src/pdm/framework/ACLManager.py
+++ b/src/pdm/framework/ACLManager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from flask import request
+from flask import current_app, request
 
 
 class ACLManager(object):
@@ -63,7 +63,7 @@ class ACLManager(object):
                 # Token decoding failed, it is probably corrupt or has been
                 # tampered with.
                 current_app.log.info("Request %s token validation failed.",
-                                     req_uuid)
+                                     request.uuid)
                 return "403 Invalid Token", 403
 
     def __get_fake_request_auth(self):

--- a/src/pdm/framework/ACLManager.py
+++ b/src/pdm/framework/ACLManager.py
@@ -40,12 +40,6 @@ class ACLManager(object):
         """
         pass
 
-    def dump_debug(self):
-        """ Dumps the configuration of the ACLManager to the logger
-            at the debug level. This includes all group and rule configuration.
-        """
-        pass
-
     def check_request(self):
         """ Gets the current flask request object and checks it against the
             configured rule set.

--- a/src/pdm/framework/FlaskWrapper.py
+++ b/src/pdm/framework/FlaskWrapper.py
@@ -329,18 +329,16 @@ class FlaskServer(Flask):
     def add_auth_rules(self, auth_rules):
         """ Adds authentication rules to the web server.
             auth_rules - A dictionary of rules, keys are URI paths,
-                         values are lists of rule statements:
+                         values are a rule statement:
                           - "CERT" - Any valid client cert is allowed.
                           - "CERT:/some/dn" - Allow a specific CERT.
                           - "TOKEN" - Any valid token is allowed.
-                          - "ANY" - Any valid credential is allowed.
                           - "ALL" - All requests are allowed.
             By default no-one can call any function.
             Returns None.
         """
-        for path, rules in auth_rules.iteritems():
-            for rule in rules:
-                self.__acl_manager.add_rule(path, rule)
+        for path, rule in auth_rules.iteritems():
+            self.__acl_manager.add_rule(path, rule)
 
     def test_mode(self, main_cls, conf="", with_test=True):
         """ Configures this app instance in test mode.

--- a/src/pdm/framework/FlaskWrapper.py
+++ b/src/pdm/framework/FlaskWrapper.py
@@ -462,11 +462,11 @@ class FlaskServer(Flask):
             "ALL" - No auth, all request anyway.
         """
         if not auth_mode:
-            self.__acl_manager(ACLManager.AUTH_MODE_NONE)
+            self.__acl_manager.test_mode(ACLManager.AUTH_MODE_NONE)
             return
         if auth_mode == "CERT":
-            self.__acl_manager(ACLManager.AUTH_MODE_X509, auth_data)
+            self.__acl_manager.test_mode(ACLManager.AUTH_MODE_X509, auth_data)
         elif auth_mode == "TOKEN":
-            self.__acl_manager(ACLManager.AUTH_MODE_TOKEN, auth_data)
+            self.__acl_manager.test_mode(ACLManager.AUTH_MODE_TOKEN, auth_data)
         else:
-            self.__acl_manager(ACLManager.AUTH_MODE_ALLOW_ALL)
+            self.__acl_manager.test_mode(ACLManager.AUTH_MODE_ALLOW_ALL)

--- a/src/pdm/framework/FlaskWrapper.py
+++ b/src/pdm/framework/FlaskWrapper.py
@@ -197,42 +197,6 @@ class FlaskServer(Flask):
         current_app.acl_manager.check_request()
         FlaskServer.__extend_request()
 
-        #if current_app.test_auth:
-        #    # We are in test mode and want fake authentication
-        #    return FlaskServer.__test_init_handler()
-        #client_dn = None
-        #client_token = False
-        #token_value = None
-        #if 'Ssl-Client-Verify' in request.headers \
-        #    and 'Ssl-Client-S-Dn' in request.headers:
-        #    # Request has client cert
-        #    if request.headers['Ssl-Client-Verify'] == 'SUCCESS':
-        #        client_dn = request.headers['Ssl-Client-S-Dn']
-        #if 'X-Token' in request.headers:
-        #    raw_token = request.headers['X-Token']
-        #    try:
-        #        token_value = current_app.token_svc.check(raw_token)
-        #    except ValueError:
-        #        # Token decoding failed, it is probably corrupt or has been
-        #        # tampered with.
-        #        current_app.log.info("Request %s token validation failed.",
-        #                             req_uuid)
-        #        return "403 Invalid Token", 403
-        #    client_token = True
-        ## Now check request against policy
-        #current_app.log.debug("Request %s, cert: %s, token: %s",
-        #                      req_uuid, bool(client_dn), client_token)
-        #if not FlaskServer.__req_allowed(client_dn, client_token):
-        #    current_app.log.info("Request %s denied by policy.", req_uuid)
-        #    return "403 Forbidden\n", 403
-        ## Finally, update request object
-        #request.dn = client_dn
-        #request.token_ok = client_token
-        #if client_token:
-        #    request.token = token_value
-        #else:
-        #    request.token = None
-
     @staticmethod
     def __access_log(resp):
         """ This function writes to the access log, to log the request details

--- a/src/pdm/framework/FlaskWrapper.py
+++ b/src/pdm/framework/FlaskWrapper.py
@@ -129,42 +129,6 @@ class FlaskServer(Flask):
         configuration & runtime helpers.
     """
 
-    #@staticmethod
-    #def __check_req(resource, client_dn, client_token):
-    #    """ Checks the request for resource against the current_app.policy.
-    #        Returns True if the request should be allowed.
-    #                False if the request should be denied.
-    #    """
-    #    for policy_path, policy_rules in current_app.policy.iteritems():
-    #        if fnmatch.fnmatch(resource, policy_path):
-    #            for rule in policy_rules:
-    #                if rule == 'ALL':
-    #                    return True
-    #                if rule == 'ANY' and (client_dn or client_token):
-    #                    return True
-    #                if rule == 'TOKEN' and client_token:
-    #                    return True
-    #                if rule == 'CERT' and client_dn:
-    #                    return True
-    #                if rule.startswith('CERT:'):
-    #                    _, check_dn = rule.split(':', 1)
-    #                    if client_dn == check_dn:
-    #                        return True
-    #    # No rules matched => Access denied
-    #    return False
-
-    #@staticmethod
-    #def __req_allowed(client_dn, client_token):
-    #    if request.url_rule:
-    #        real_path = request.url_rule.rule.split('<')[0]
-    #    else:
-    #        real_path = request.path
-    #    # Strip a trailing slash, as long as it isn't the only char
-    #    if real_path.endswith('/') and len(real_path) > 1:
-    #        real_path = real_path[:-1]
-    #    resource = "%s%%%s" % (real_path, request.method)
-    #    return FlaskServer.__check_req(resource, client_dn, client_token)
-
     @staticmethod
     def __extend_request():
         """ Adds a few extra items into request from current_app for

--- a/test/pdm/cred/test_CredService.py
+++ b/test/pdm/cred/test_CredService.py
@@ -139,7 +139,7 @@ class test_CredService(unittest.TestCase):
                 x509_obj = X509.load_cert_string(cred_str)
                 user_serial = x509_obj.get_serial_number()
                 user_dn = X509Utils.x509name_to_str(x509_obj.get_subject())
-                templ_dn = "C = XX, OU = Test Users, CN = User_%u " % \
+                templ_dn = "C=XX, OU=Test Users, CN=User_%u " % \
                                TEST_USER_ID
                 self.assertIn(templ_dn, user_dn)
                 # TODO: Check user e-mail was stored in cert

--- a/test/pdm/framework/test_ACLManager.py
+++ b/test/pdm/framework/test_ACLManager.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+""" ACLManager module tests. """
+
+import logging
+import unittest
+
+from pdm.framework.ACLManager import ACLManager
+
+class TestACLManager(unittest.TestCase):
+    """ Test the ACLManager class. """
+
+    def setUp(self):
+        """ Create an instance of ACLManager to test. """
+        self.__inst = ACLManager(logging.getLogger())
+
+    def __gen_req(self, method, path, auth_mode, auth_data):
+        """ Call self.__inst.check_request while generating a fake request
+            with the given parameters (without using test_mode on the 
+            ACLManager).
+            Returns True if the request was successful (i.e. access would
+            have been allowed).
+        """
+        # TODO: implement this
+        return False
+
+    def test_basic(self):
+        """ Add simple ANY rules and see if they work. """
+        # TODO: implement this
+        pass
+
+    def test_groups(self):
+        """ Check that groups are applied correctly. """
+        # TODO: implement this
+        pass
+
+    def test_auth_modes(self):
+        """ Check that all auth modes work as expected. """
+        # TODO: implement this
+        pass
+
+    def test_test_mode(self):
+        """ Check that test mode works correctly. """
+        # TODO: implement this
+        pass
+
+    def test_wildcards(self):
+        """ Check that test mode works correctly. """
+        # TODO: implement this
+        pass
+

--- a/test/pdm/framework/test_ACLManager.py
+++ b/test/pdm/framework/test_ACLManager.py
@@ -4,47 +4,250 @@
 import logging
 import unittest
 
+from flask import Flask, current_app, request
+from werkzeug.exceptions import Forbidden, NotFound
+from pdm.utils.X509 import X509Utils
 from pdm.framework.ACLManager import ACLManager
+
+class FakeTokenSVC(object):
+    """ A fake token service class for testing ACL Manager. """
+
+    def __init__(self, token_ok=True):
+        self.__token_ok = token_ok
+
+    def check(self, raw_token):
+        if not self.__token_ok:
+            raise ValueError("Invalid Token")
+        return raw_token
+
 
 class TestACLManager(unittest.TestCase):
     """ Test the ACLManager class. """
 
     def setUp(self):
         """ Create an instance of ACLManager to test. """
-        self.__inst = ACLManager(logging.getLogger())
+        self.__log = logging.getLogger()
+        self.__inst = ACLManager(self.__log)
 
-    def __gen_req(self, method, path, auth_mode, auth_data):
+    def __gen_req(self, path, method="GET",
+                  auth_mode=ACLManager.AUTH_MODE_NONE, auth_data=None,
+                  cert_ok=True, token_ok=True):
         """ Call self.__inst.check_request while generating a fake request
             with the given parameters (without using test_mode on the 
             ACLManager).
             Returns True if the request was successful (i.e. access would
             have been allowed).
         """
-        # TODO: implement this
-        return False
+        app = Flask("ACLManagertest")
+        token_svc = FakeTokenSVC(token_ok)
+        try:
+            headers = {}
+            if auth_mode == ACLManager.AUTH_MODE_X509:
+                if cert_ok:
+                    headers['Ssl-Client-Verify'] = 'SUCCESS'
+                else:
+                    headers['Ssl-Client-Verify'] = 'FAILED'
+                headers['Ssl-Client-S-Dn'] = auth_data
+            elif auth_mode == ACLManager.AUTH_MODE_TOKEN:
+                headers['X-Token'] = auth_data
+            with app.test_request_context(path=path, method=method,
+                                          headers=headers):
+                # Prepare a standard looking request
+                current_app.log = self.__log
+                current_app.token_svc = token_svc
+                request.uuid = "Test-Test-Test"
+                # Call the check function
+                self.__inst.check_request()
+                # Check that request info was correctly propagated
+                if auth_mode == ACLManager.AUTH_MODE_X509:
+                    norm_dn = X509Utils.normalise_dn(auth_data)
+                    self.assertEqual(request.dn, norm_dn)
+                elif auth_mode == ACLManager.AUTH_MODE_TOKEN:
+                    if token_ok:
+                        self.assertEqual(request.token, auth_data)
+                        self.assertTrue(request.token_ok)
+                    else:
+                        self.assertFalse(request.token_ok)
+            # Access was allowed (no exception raised)
+            return True
+        except Forbidden:
+            # Access was denied (Forbidden exception thrown)
+            return False
 
     def test_basic(self):
-        """ Add simple ANY rules and see if they work. """
-        # TODO: implement this
-        pass
-
-    def test_groups(self):
-        """ Check that groups are applied correctly. """
-        # TODO: implement this
-        pass
+        """ Add simple ALL rules and see if they work. """
+        self.__inst.add_rule("/test1", "ALL")
+        self.__inst.add_rule("/test2", "ALL")
+        self.__inst.add_rule("/test/nested", "ALL")
+        self.__inst.add_rule("/test/post%MISC", "ALL")
+        self.__inst.add_rule("/test/multi%POST", "ALL")
+        self.__inst.add_rule("/test/multi%PUT", "ALL")
+        self.assertFalse(self.__gen_req("/"))
+        self.assertTrue(self.__gen_req("/test1"))
+        self.assertTrue(self.__gen_req("/test1/"))
+        self.assertTrue(self.__gen_req("/test2"))
+        self.assertFalse(self.__gen_req("/test"))
+        self.assertFalse(self.__gen_req("/test/nest"))
+        self.assertTrue(self.__gen_req("/test/nested"))
+        self.assertFalse(self.__gen_req("/test/post", "GET"))
+        self.assertTrue(self.__gen_req("/test/post", "MISC"))
+        self.assertTrue(self.__gen_req("/test/multi", "POST"))
+        self.assertTrue(self.__gen_req("/test/multi", "PUT"))
+        self.assertFalse(self.__gen_req("/test/multi", "GET"))
+        # Check that requests containing a % char are always rejected.
+        self.assertRaises(NotFound, self.__gen_req, "/test/test/test%%")
 
     def test_auth_modes(self):
         """ Check that all auth modes work as expected. """
-        # TODO: implement this
-        pass
+        self.__inst.add_rule("/cert_only", "CERT")
+        self.__inst.add_rule("/cert_dn1", "CERT:/C=XX/OU=Test/CN=Test User1")
+        self.__inst.add_rule("/cert_dn2", "CERT:C = YY, OU = Bah, CN = Test User2")
+        self.__inst.add_rule("/token_only", "TOKEN")
+        self.__inst.add_rule("/all", "ALL")
+        # Now test that each auth mode only works with the expected endpoint
+        # We do this by looping over every endpoint in the TEST_EP list and
+        # trying them with certain authentication parameters.
+        TEST_EP = ["/cert_only", "/cert_dn1", "/cert_dn2",
+                   "/token_only", "/all", "/none"]
+        # AUTH_TESTs is a list of tuples: (auth_mode, auth_data, res)
+        # res is a list of whether each TEST_EP should be expected to work
+        # with this endpoint or not (in the order of TEST_EP)
+        AUTH_TESTS = [
+          (ACLManager.AUTH_MODE_X509, 'C = XX, OU = Test, CN = Test User1',
+           (True, True, False, False, True, False, )),
+          (ACLManager.AUTH_MODE_X509, 'C = YY, OU = Bah, CN = Test User2',
+           (True, False, True, False, True, False, )),
+          (ACLManager.AUTH_MODE_X509, 'C = ZZ, OU = Other, CN = Test User3',
+           (True, False, False, False, True, False, )),
+          (ACLManager.AUTH_MODE_TOKEN, 'TOKENTEXT',
+           (False, False, False, True, True, False, )),
+          (ACLManager.AUTH_MODE_TOKEN, 'OTHERTOKENTEXT',
+           (False, False, False, True, True, False, )),
+          (ACLManager.AUTH_MODE_NONE, None,
+           (False, False, False, False, True, False, )),
+        ]
+        for auth_mode, auth_data, auth_res in AUTH_TESTS:
+            for i in xrange(0, len(TEST_EP)):
+                res = self.__gen_req(TEST_EP[i], "GET", auth_mode, auth_data)
+                self.assertEqual(res, auth_res[i],
+                    "Path %s failed, auth_data=%s, Expected: %s, Actual: %s" % \
+                    (TEST_EP[i], auth_data, auth_res[i], res))
+        # Finally, check that token fails if the token provided is bad
+        res = self.__gen_req("/token_only", "GET", ACLManager.AUTH_MODE_TOKEN,
+                             "BAD_TOKEN", token_ok=False)
+        self.assertFalse(res)
+                                        
+
+    def test_groups(self):
+        """ Check that groups are applied correctly. """
+        self.__inst.add_group_entry("grp1", "ALL")
+        self.__inst.add_rule("/group1", "@grp1")
+        self.__inst.add_group_entry("grp2", "CERT")
+        self.__inst.add_group_entry("grp2", "TOKEN")
+        self.__inst.add_rule("/group2", "@grp2")
+        # Missing group
+        self.assertRaises(ValueError, self.__inst.add_rule,
+                          "/group3", "@grp3")
+        # Check the groups work as expected
+        self.assertTrue(self.__gen_req("/group1"))
+        self.assertTrue(self.__gen_req("/group1", "GET",
+                        ACLManager.AUTH_MODE_X509, "CN=Test"))
+        self.assertTrue(self.__gen_req("/group1", "GET",
+                        ACLManager.AUTH_MODE_TOKEN, "TOKENSTR"))
+        self.assertFalse(self.__gen_req("/group2"))
+        self.assertTrue(self.__gen_req("/group2", "GET",
+                        ACLManager.AUTH_MODE_X509, "CN=Test"))
+        self.assertTrue(self.__gen_req("/group2", "GET",
+                        ACLManager.AUTH_MODE_TOKEN, "TOKENSTR"))
+
+    def test_bad_rules(self):
+        """ Check that malformed rules and groups are rejected. """
+        # Bad auth type
+        self.assertRaises(ValueError,
+                          self.__inst.add_rule, "/bad", "BAD")
+        # Nested Group
+        self.__inst.add_group_entry("grp1", "ALL")
+        self.assertRaises(ValueError,
+                          self.__inst.add_group_entry, "/bad", "@grp1")
+        # Cert with no DN
+        self.assertRaises(ValueError,
+                          self.__inst.add_rule, "/bad", "CERT:")
+        # Two rules for the same path
+        self.__inst.add_rule("/good", "TOKEN")
+        self.assertRaises(ValueError,
+                          self.__inst.add_rule, "/good", "CERT")
+
+    def test_wildcards(self):
+        """ Check that wildcards work as expected. """
+        self.__inst.add_rule("/ep1/?", "ALL")
+        self.__inst.add_rule("/ep1/test/?", "ALL")
+        self.__inst.add_rule("/ep1/test/?/test2", "ALL")
+        self.__inst.add_rule("/ep1/test/?/test2/?", "ALL")
+        self.__inst.add_rule("/ep2/test/?/?", "ALL")
+        self.__inst.add_rule("/ep3/test/*", "ALL")
+        self.__inst.add_rule("/ep4/*/test", "ALL")
+        self.__inst.add_rule("/ep5/?/test%POST", "ALL")
+        # Check paths work as expected
+        # EP1
+        self.assertFalse(self.__gen_req("/ep1"))
+        self.assertTrue(self.__gen_req("/ep1/blah"))
+        self.assertTrue(self.__gen_req("/ep1/test"))
+        self.assertFalse(self.__gen_req("/ep1/blah/bad"))
+        self.assertTrue(self.__gen_req("/ep1/test/blah"))
+        self.assertTrue(self.__gen_req("/ep1/test/blah/test2"))
+        self.assertTrue(self.__gen_req("/ep1/test/blah/test2/blah2"))
+        self.assertFalse(self.__gen_req("/ep1/test/blah/test3"))
+        # EP2
+        self.assertFalse(self.__gen_req("/ep2"))
+        self.assertFalse(self.__gen_req("/ep2/test/blah2"))
+        self.assertTrue(self.__gen_req("/ep2/test/blah2/extra"))
+        # EP3
+        self.assertFalse(self.__gen_req("/ep3"))
+        self.assertFalse(self.__gen_req("/ep3/test"))
+        self.assertTrue(self.__gen_req("/ep3/test/extra1"))
+        self.assertTrue(self.__gen_req("/ep3/test/extra1/extra2"))
+        # EP4
+        self.assertFalse(self.__gen_req("/ep4/blah/test"))
+        self.assertFalse(self.__gen_req("/ep4/blah/blah/test"))
+        # EP5
+        self.assertFalse(self.__gen_req("/ep5/blah/test", "GET"))
+        self.assertTrue(self.__gen_req("/ep5/blah/test", "POST"))
+        # Special case: only wildcard
+        self.__inst.add_rule("*", "ALL")
+        self.assertTrue(self.__gen_req("/"))
+        self.assertTrue(self.__gen_req("/special"))
+        self.assertTrue(self.__gen_req("/special/special"))
+
+    def test_wildcard_but_wrong_auth(self):
+        """ Simply test wildcard rule which matches one auth type,
+            but the user has a different auth type.
+        """
+        self.__inst.add_rule("/test/?", "CERT")
+        self.assertFalse(self.__gen_req("/test/blah", "GET",
+                                        ACLManager.AUTH_MODE_TOKEN, "X"))
+        self.assertTrue(self.__gen_req("/test/blah", "GET",
+                                        ACLManager.AUTH_MODE_X509, "C=X"))
+
+    def __check_test_mode(self, auth_mode, auth_data):
+        """ Helper function for testing test_mode.
+        """
+        self.__inst.test_mode(auth_mode, auth_data)
+        app = Flask("ACLManagertest")
+        with app.test_request_context(path="/test", method="GET"):
+            request.uuid = "Test-Test-Test"
+            # Call the check function
+            self.__inst.check_request()
+            # Check that request info was correctly propagated
+            if auth_mode == ACLManager.AUTH_MODE_X509:
+                norm_dn = X509Utils.normalise_dn(auth_data)
+                self.assertEqual(request.dn, norm_dn)
+            elif auth_mode == ACLManager.AUTH_MODE_TOKEN:
+                self.assertEqual(request.token, auth_data)
+                self.assertTrue(request.token_ok)
 
     def test_test_mode(self):
         """ Check that test mode works correctly. """
-        # TODO: implement this
-        pass
-
-    def test_wildcards(self):
-        """ Check that test mode works correctly. """
-        # TODO: implement this
-        pass
-
+        self.__check_test_mode(ACLManager.AUTH_MODE_X509, "/C=XX/CN=Test1")
+        self.__check_test_mode(ACLManager.AUTH_MODE_X509, "C=YY,CN=Test2")
+        self.__check_test_mode(ACLManager.AUTH_MODE_TOKEN, "TOKENSTR")
+        self.__check_test_mode(ACLManager.AUTH_MODE_TOKEN, "TEST2")

--- a/test/pdm/utils/test_X509.py
+++ b/test/pdm/utils/test_X509.py
@@ -96,7 +96,7 @@ class TestX509Utils(unittest.TestCase):
         """ Test the X509_Name import/export functions. """
         from M2Crypto import X509
         # Convert a DN into an object and back
-        TEST_DN = 'C = UK, L = London, O = Test Corp., OU = Security, CN = DN Tester'
+        TEST_DN = 'C=UK, L=London, O=Test Corp., OU=Security, CN=DN Tester'
         x509_obj = X509Utils.str_to_x509name(TEST_DN)
         self.assertIsInstance(x509_obj, X509.X509_Name)
         self.assertEqual(x509_obj.C, 'UK')
@@ -106,13 +106,34 @@ class TestX509Utils(unittest.TestCase):
         self.assertEqual(x509_obj.CN, 'DN Tester')
         self.assertEqual(X509Utils.x509name_to_str(x509_obj), TEST_DN)
         # Bonus: Convert a DN with two similar segments
-        TEST_DN = 'C = UK, CN = Test User, CN = Proxy'
+        TEST_DN = 'C=UK, CN=Test User, CN=Proxy'
         x509_obj = X509Utils.str_to_x509name(TEST_DN)
         self.assertIsInstance(x509_obj, X509.X509_Name)
         # Interface currently prevents access to multiple fields
         # i.e. x509_obj.CN will only return "Test User".
         # Just check that all fields appear if object is converted back:
         self.assertEqual(X509Utils.x509name_to_str(x509_obj), TEST_DN)
+
+    def test_dn_normalisation(self):
+        """ Test the X509 DN normalisation function. """
+        # Test DN in expected output format
+        TEST_DN = "C=XX, L=YY, CN=Test CA"
+        # Test both RFC and OpenSSL style DNs with increasing amounts of space
+        # All should match the TEST_DN after normalisation.
+        self.assertEqual(X509Utils.normalise_dn(TEST_DN), TEST_DN)
+        self.assertEqual(X509Utils.normalise_dn("/C=XX/L=YY/CN=Test CA"),
+                         TEST_DN)
+        self.assertEqual(X509Utils.normalise_dn("/C=XX / L =  YY /  CN = Test CA  "),
+                         TEST_DN)
+        # Check that leading space doesn't upset the algorithm
+        self.assertEqual(X509Utils.normalise_dn("   / C =XX / L =  YY /  CN = Test CA  "),
+                         TEST_DN)
+        self.assertEqual(X509Utils.normalise_dn("C = XX, L = YY, CN = Test CA"),
+                         TEST_DN)
+        self.assertEqual(X509Utils.normalise_dn("C  =  XX,   L  =  YY,    CN = Test CA   "),
+                         TEST_DN)
+        self.assertEqual(X509Utils.normalise_dn("     C  =  XX,   L  =  YY,    CN = Test CA"),
+                         TEST_DN)
 
     def test_get_cert_expiry(self):
         """ Test that the get_cert_expiry function works. """
@@ -171,7 +192,7 @@ class TestX509CA(unittest.TestCase):
         self.assertTrue(self.__ca.ready())
         # Get DN returns value in RFC format.
         self.assertEquals(self.__ca.get_dn(),
-                          "C = XX, L = YY, CN = Test CA")
+                          "C=XX, L=YY, CN=Test CA")
 
 
     @mock.patch('M2Crypto.X509.Request')
@@ -303,7 +324,7 @@ class TestX509CA(unittest.TestCase):
             re-import it again afterwards. Both with and
             without a passphrase.
         """
-        TEST_DN = "C = ZZ, CN = Yet Another CA"
+        TEST_DN = "C=ZZ, CN=Yet Another CA"
         constr_params = (TEST_DN, 4)
         for passphrase in (None, 'weakpass'):
             print "Test passphrase: %s" % passphrase
@@ -345,8 +366,8 @@ class TestX509CA(unittest.TestCase):
     def test_gen_cert(self):
         """ Check issuing a client certificate. """
         from M2Crypto import X509, RSA
-        TEST_ISSUER = "C = ZZ, L = YY, O = Test CA, CN = Basic Test CA"
-        TEST_SUBJECT = "C = ZZ, L = YY, CN = Test User"
+        TEST_ISSUER = "C=ZZ, L=YY, O=Test CA, CN=Basic Test CA"
+        TEST_SUBJECT = "C=ZZ, L=YY, CN=Test User"
         TEST_EMAIL = "test@test.test"
         TEST_DAYS = 3
         self.__ca.gen_ca(TEST_ISSUER, 5)
@@ -430,8 +451,8 @@ class TestX509CA(unittest.TestCase):
         """ Test generating a user proxy. """
         from M2Crypto import X509, RSA
         TEST_HOURS = 14
-        USER_DN = "C = XX, CN = Test User"
-        self.__ca.gen_ca("C = XX, CN = Test CA", 5)
+        USER_DN = "C=XX, CN=Test User"
+        self.__ca.gen_ca("C=XX, CN=Test CA", 5)
         usercert, userkey = self.__ca.gen_cert(USER_DN, 4)
         proxycert, proxykey = self.__ca.gen_proxy(usercert, userkey,
                                                   TEST_HOURS)
@@ -439,7 +460,7 @@ class TestX509CA(unittest.TestCase):
         proxy_obj = X509.load_cert_string(proxycert)
         proxy_serial = proxy_obj.get_serial_number()
         proxy_subject = X509Utils.x509name_to_str(proxy_obj.get_subject())
-        exp_proxy_subj = "%s, CN = %u" % (USER_DN, proxy_serial)
+        exp_proxy_subj = "%s, CN=%u" % (USER_DN, proxy_serial)
         self.assertEqual(exp_proxy_subj, proxy_subject)
         proxy_issuer = X509Utils.x509name_to_str(proxy_obj.get_issuer())
         self.assertEqual(proxy_issuer, USER_DN)
@@ -473,7 +494,7 @@ class TestX509CA(unittest.TestCase):
         self.assertEqual(user_id.get_value(), test_value)
         # Test generating proxy with passphrase
         USER_PASSPHRASE = "weaktest"
-        usercert, userkey = self.__ca.gen_cert("/C=XX, CN=Test User", 4,
+        usercert, userkey = self.__ca.gen_cert("/C=XX/CN=Test User", 4,
                                                passphrase=USER_PASSPHRASE)
         self.assertRaises(RSA.RSAError, self.__ca.gen_proxy, usercert,
                           userkey, 1)
@@ -505,6 +526,9 @@ class TestX509CA(unittest.TestCase):
         x509_pubkey.as_der.return_value = "ABCD"
         x509_obj = mock.MagicMock()
         x509_obj.get_pubkey.return_value = x509_pubkey
+        dn_obj = mock.MagicMock()
+        dn_obj.as_text.return_value = "OU = Mock DN"
+        x509_obj.get_subject.return_value = dn_obj
         x509_constr.return_value = x509_obj
         not_before.return_value = None
         not_after.return_value = None


### PR DESCRIPTION
This moves the access code out of FlaskWrapper into its own class where it can be more readily tested. It changes the auth file format to be more understandable (no more magic for <int> style endpoints) and adds a comprehensive set of tests.

Closes #65. Closes #68.
