### PR TITLE
Set secret_key in FlaskWrapper

### DIFF
--- a/src/pdm/framework/FlaskWrapper.py
+++ b/src/pdm/framework/FlaskWrapper.py
@@ -225,6 +225,7 @@ class FlaskServer(Flask):
         self.__startup_funcs = []
         self.__test_funcs = []
         self.__logger = logger
+        self.secret_key = token_key + "flask"
         self.token_svc = TokenService(token_key, "pdmwebsvc")
         # We override the test client class from Flask with our
         # custom one which is more similar to RESTClient

--- a/src/pdm/framework/FlaskWrapper.py
+++ b/src/pdm/framework/FlaskWrapper.py
@@ -225,6 +225,8 @@ class FlaskServer(Flask):
         self.__startup_funcs = []
         self.__test_funcs = []
         self.__logger = logger
+        if not token_key:
+            token_key = os.urandom(16)
         self.secret_key = token_key + "flask"
         self.token_svc = TokenService(token_key, "pdmwebsvc")
         # We override the test client class from Flask with our

--- a/src/pdm/web/WebPageService.py
+++ b/src/pdm/web/WebPageService.py
@@ -18,15 +18,13 @@ class WebPageService(object):
     @staticmethod
     @startup
     #pylint: disable=unused-argument
-    def preload_turtles(config):
+    def startup_web(config):
         """ Configure the turtles application.
             Creates an example database if DB is entry.
             Prints valud of "test_param" from the config.
         """
-        # TODO: this should come from the framework
-        flask.current_app.secret_key = 'muhahaha'
         log = flask.current_app.log
-        log.info("Hello Real Turtles")
+        log.info("Web interface starting")
         flask.current_app.hrclient = HRClient()
         flask.current_app.epclient = EndpointClient()
 


### PR DESCRIPTION
This moves setting the secret_key for Flask cookies into the main framework... For @marianne013 to test (as there are no unit tests for this module yet ;-)
