### PR TITLE
Force required attrs from the Worker client.

### DIFF
--- a/src/pdm/workqueue/WorkqueueService.py
+++ b/src/pdm/workqueue/WorkqueueService.py
@@ -42,6 +42,7 @@ class WorkqueueService(object):
     @decode_json_data
     def get_next_job():
         """Get the next job."""
+        require_attrs('types')
         Job = request.db.tables.Job  # pylint: disable=invalid-name
         job = Job.query.filter(Job.status.in_((JobStatus.NEW, JobStatus.FAILED)),
                                Job.type.in_(request.data['types']),
@@ -61,6 +62,7 @@ class WorkqueueService(object):
             abort(403, description="Invalid token")
         if int(request.token) != job_id:
             abort(403, description="Token not valid for job %d" % job_id)
+        require_attrs('returncode', 'host', 'log')
 
         # Update job status.
         Job = request.db.tables.Job  # pylint: disable=invalid-name

--- a/test/pdm/workqueue/test_WorkqueueService.py
+++ b/test/pdm/workqueue/test_WorkqueueService.py
@@ -30,6 +30,8 @@ class TestWorkqueueService(unittest.TestCase):
 
     def test_get_next_job(self):
         """test worker get next job."""
+        request = self.__test.post('/workqueue/api/v1.0/worker', data={'test': 12})
+        self.assertEqual(request.status_code, 400, "Expected job with incorrect attrs to fail.")
         request = self.__test.post('/workqueue/api/v1.0/worker', data={'types': [JobType.LIST]})
         self.assertEqual(request.status_code, 200, "Request to get worker job failed.")
         job, token = json.loads(request.data)
@@ -67,6 +69,11 @@ class TestWorkqueueService(unittest.TestCase):
         self.assertEqual(request.status_code, 403)
 
         self.__service.fake_auth("TOKEN", "100")
+        request = self.__test.put('/workqueue/api/v1.0/worker/100',
+                                   data={'returncode': 0,
+                                         'host': 'somehost.domain'})
+        self.assertEqual(request.status_code, 400)
+
         request = self.__test.put('/workqueue/api/v1.0/worker/100',
                                    data={'log': 'blah blah',
                                          'returncode': 0,


### PR DESCRIPTION
This is only worker facing changes so doesn't impact the public client API. Makes the service a bit more bulletproof.