### PR TITLE
Add sitepackages flag to tox for EL7 testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = unit
 [testenv]
 # Inherited by other test environments
 basepython=python2.7
+# Required to allow pyOpenSSL from host on EL7
+sitepackages=True
 
 # Standard unit testing + coverage
 [testenv:unit]


### PR DESCRIPTION
This allows tox to pull in sitepackages from the host machines... While this risks contaminating the test environment, it seems to be the only way to get the dependencies reliably available on older platforms (specifically EL7). As far as I can tell it doesn't currently change the test results on Fedora or Travis, so I think it's OK for now.

(When I say dependencies, it's mainly the ones that rely on compatibility with the host C library, such as M2Crypto and pyOpenSSL).