### PR TITLE
 add -s/--protocol option to the CLI

### DIFF
--- a/src/pdm/CLI/user_subcommand.py
+++ b/src/pdm/CLI/user_subcommand.py
@@ -44,7 +44,8 @@ class UserCommand(object):
         user_parser.add_argument('-t', '--token', type=str, required=True)
         user_parser.add_argument('site', type=str)
         user_parser.add_argument('-m', '--max_tries', type=int, help='max tries')
-        user_parser.add_argument('-p', type=int, help='priority')
+        user_parser.add_argument('-p', '--priority', type=int, help='priority')
+        user_parser.add_argument('-s', '--protocol', type=str, help='protocol')
         user_parser.set_defaults(func=self.list)
         # remove
         user_parser = subparsers.add_parser('remove', help="remove files from remote site.")
@@ -53,6 +54,7 @@ class UserCommand(object):
         user_parser.add_argument('-m', '--max_tries', type=int)
         user_parser.add_argument('-p', '--priority', type=int)
         user_parser.add_argument('-b', '--block', action='store_true')
+        user_parser.add_argument('-s', '--protocol', type=str, help='protocol')
         user_parser.set_defaults(func=self.remove)
         # copy
         user_parser = subparsers.add_parser('copy',
@@ -63,6 +65,7 @@ class UserCommand(object):
         user_parser.add_argument('-m', '--max_tries', type=int)
         user_parser.add_argument('-p', '--priority', type=int)
         user_parser.add_argument('-b', '--block', action='store_true')
+        user_parser.add_argument('-s', '--protocol', type=str, help='protocol')
         user_parser.set_defaults(func=self.copy)
         # site list
         user_parser = subparsers.add_parser('sites',

--- a/src/pdm/userservicedesk/HRService.py
+++ b/src/pdm/userservicedesk/HRService.py
@@ -302,7 +302,8 @@ class HRService(object):
         :return: True of False
         """
         if len(passwd) < current_app.pwd_len:
-            HRService._logger.error("Password too short %d (lower limit = %d)", len(passwd), current_app.pwd_len)
+            HRService._logger.error("Password too short %d (lower limit = %d)",
+                                    len(passwd), current_app.pwd_len)
             return False
 
         return True

--- a/src/pdm/userservicedesk/TransferClientFacade.py
+++ b/src/pdm/userservicedesk/TransferClientFacade.py
@@ -99,7 +99,12 @@ class MockTransferClientFacade(object):
         return str(site)
 
     @staticmethod
-    def output(self, id):
+    def output(id):
+        """
+        Duumy to be mocked away
+        :param id:
+        :return:
+        """
         return "job id %s listnig: whatever", id
 
     @staticmethod

--- a/test/pdm/CLI/test_usercommand.py
+++ b/test/pdm/CLI/test_usercommand.py
@@ -106,11 +106,11 @@ class TestUsercommand(unittest.TestCase):
         mocked_facade.return_value = MockTransferClientFacade("anything")
         mocked_facade.return_value.status = mock.MagicMock()
         mocked_facade.return_value.status.return_value = {'status':'DONE', 'id': 1}
-
-        args = self._parser.parse_args('remove source  -m 3 -t gfsdgfhsgdfh'.split())
+        # protocol swittch is -s !!!
+        args = self._parser.parse_args('remove source -s gsiftp -m 3 -t gfsdgfhsgdfh'.split())
         args.func(args)
 
-        mock_remove.assert_called_with('source', max_tries=3)
+        mock_remove.assert_called_with('source', max_tries=3, protocol='gsiftp')
         assert mocked_facade.return_value.status.call_count == 1
 
         mocked_facade.return_value.status.reset_mock()


### PR DESCRIPTION
The single character switch is '-s' since '-p' is already used for priority. The test shows that the workqueue system is called with a correct priority='gsiftp' argument.