### PR TITLE
Making the JSONMixin more generic.

### DIFF
--- a/src/pdm/framework/Database.py
+++ b/src/pdm/framework/Database.py
@@ -45,9 +45,14 @@ class DictMixin(object):
     @property
     def columns(self):
         """list of db model column names."""
-        return [column.name for column in self.__table__.columns
-                if column.name not in self.__excluded_fields__]
+        return [name for name, _ in self]
 
+    # This doesn't match the return from a normal mapping which is just keys.
+    # This is necessary to allow dictionary conversion as dict constructor
+    # doesn't recognise this class as a Mapping despite the manual registration.
+    # Only way to change this is to give flask_sqlalchemy.make_declarative_base()
+    # a new meta which is a subclass of ABCMeta. Our version doesn't allow this so
+    # until we can update we have to do it this way.
     def __iter__(self):
         """Iterator through db columns."""
         return ((column.name, getattr(self, column.name)) for column in self.__table__.columns

--- a/src/pdm/framework/Database.py
+++ b/src/pdm/framework/Database.py
@@ -50,7 +50,7 @@ class DictMixin(object):
 
     def __iter__(self):
         """Iterator through db columns."""
-        return ((column.name, self[column.name]) for column in self.__table__.columns
+        return ((column.name, getattr(self, column.name)) for column in self.__table__.columns
                 if column.name not in self.__excluded_fields__)
 
     def __getitem__(self, item):

--- a/test/pdm/framework/test_Database.py
+++ b/test/pdm/framework/test_Database.py
@@ -87,12 +87,11 @@ class TestDBJson(unittest.TestCase):
         """
         class TestCls(JSONMixin):
             # Fake SQLAlchemy table structure
-            columns = (mock.Mock(), mock.Mock(), mock.Mock())
-            columns[0].name = 'A'
-            columns[1].name = 'B'
-            columns[2].name = 'C'
             __table__ = mock.Mock()
-            __table__.columns = columns
+            __table__.columns = (mock.Mock(), mock.Mock(), mock.Mock())
+            __table__.columns[0].name = 'A'
+            __table__.columns[1].name = 'B'
+            __table__.columns[2].name = 'C'
             # Try to exclude field B
             __excluded_fields__ = ('B')
             A = "TestA"
@@ -103,18 +102,17 @@ class TestDBJson(unittest.TestCase):
         json_str = obj.json()
         # Convert the json back to an object and check the fields
         ret_obj = json.loads(json_str)
+        self.assertEqual(len(obj), 2)
         self.assertDictEqual({'A': 'TestA',
                               'C': 123}, ret_obj)
-
     def test_jsonTable(self):
         """ Check that we can serialise an SQLAlchemy table class.
         """
         class TestCls(JSONMixin):
-            columns = (mock.Mock(), mock.Mock())
-            columns[0].name = 'A'
-            columns[1].name = 'B'
             __table__ = mock.Mock()
-            __table__.columns = columns
+            __table__.columns = (mock.Mock(), mock.Mock())
+            __table__.columns[0].name = 'A'
+            __table__.columns[1].name = 'B'
 
             def __init__(self, A, B):
                 self.A = A


### PR DESCRIPTION
Hi Simon,
These are the changes to the JSON Mixin that I was talking about. Firstly since the default JSON Mixin basically made a dict of the model it now inherits from DictMixin. Secondly, you will notice that the responsibility for the encoding lies in the Mixin rather than in the encoder. This means it can be overridden by the model. Essentially the model should be responsible for how it is encoded. This will help me certainly as I won't have to maintain my own encoder.

What are your thoughts?