### PR TITLE
Generalise the JSONEncoder.

### DIFF
--- a/src/pdm/cred/CredService.py
+++ b/src/pdm/cred/CredService.py
@@ -273,7 +273,7 @@ class CredService(object):
         newest_cred = UserCred.query.filter_by(user_id=user_id) \
                                     .order_by(UserCred.expiry_date.desc()) \
                                     .first_or_404()
-        res = {'valid_until': newest_cred.expiry_date}
+        res = {'valid_until': newest_cred.expiry_date.isoformat()}
         return jsonify(res)
 
     @staticmethod

--- a/src/pdm/framework/Database.py
+++ b/src/pdm/framework/Database.py
@@ -81,7 +81,12 @@ class JSONMixin(DictMixin):
 
     def encode_for_json(self):
         """Return an object that can be encoded with the default JSON encoder."""
-        return dict(self)
+        ret = {}
+        for key, value in self:
+            if isinstance(value, datetime):
+                value = value.isoformat()
+            ret[key] = value
+        return ret
 
     def json(self):
         """JSONify the table object."""
@@ -99,8 +104,6 @@ class JSONTableEncoder(json.JSONEncoder):
     # pylint: disable=method-hidden
     def default(self, obj):
         """Default encoding method."""
-        if isinstance(obj, datetime):
-            return obj.isoformat()
         if isinstance(obj, JSONMixin):
             return obj.encode_for_json()
         return super(JSONTableEncoder, self).default(obj)

--- a/test/pdm/framework/test_Database.py
+++ b/test/pdm/framework/test_Database.py
@@ -68,14 +68,12 @@ class TestDBJson(unittest.TestCase):
         """ Test that JSONTableEncoder works on plain objects,
             including date-times.
         """
-        my_time = datetime.datetime.now()
-        test_dict = {'A': 1, 'B': 2, 'C': my_time}
+        test_dict = {'A': 1, 'B': 2}
         json_str = json.dumps(test_dict, cls=JSONTableEncoder)
         output_dict = json.loads(json_str)
         self.assertItemsEqual(test_dict.keys(), output_dict.keys())
         self.assertEqual(test_dict['A'], output_dict['A'])
         self.assertEqual(test_dict['B'], output_dict['B'])
-        self.assertEqual(my_time.isoformat(), output_dict['C'])
         # Other objects should fall through to the default,
         # which causes a TypeError
         self.assertRaises(TypeError, json.dumps,

--- a/test/pdm/framework/test_Database.py
+++ b/test/pdm/framework/test_Database.py
@@ -65,8 +65,7 @@ class TestDBJson(unittest.TestCase):
     """ Test database JSON methods. """
 
     def test_plain(self):
-        """ Test that JSONTableEncoder works on plain objects,
-            including date-times.
+        """ Test that JSONTableEncoder works on plain objects.
         """
         test_dict = {'A': 1, 'B': 2}
         json_str = json.dumps(test_dict, cls=JSONTableEncoder)


### PR DESCRIPTION
This I think is the last piece of the puzzle. This moves the datetime formatting into the Mixin class. If you leave it in the encoder then you will get a different behaviour when using Minix.json() which won't use the encoder vs json.dumps(blah, cls=Encoder) as used in jsonify.

Again this puts full responsibility for jsonifying with the model, with JSONMixin providing the same default datetime encoding as we used to get.