### PR TITLE
Allowing the JSONTableEncoder to encode datetime objects as well.

### DIFF
--- a/src/pdm/cred/CredService.py
+++ b/src/pdm/cred/CredService.py
@@ -273,7 +273,7 @@ class CredService(object):
         newest_cred = UserCred.query.filter_by(user_id=user_id) \
                                     .order_by(UserCred.expiry_date.desc()) \
                                     .first_or_404()
-        res = {'valid_until': newest_cred.expiry_date.isoformat()}
+        res = {'valid_until': newest_cred.expiry_date}
         return jsonify(res)
 
     @staticmethod

--- a/src/pdm/framework/Database.py
+++ b/src/pdm/framework/Database.py
@@ -104,6 +104,8 @@ class JSONTableEncoder(json.JSONEncoder):
     # pylint: disable=method-hidden
     def default(self, obj):
         """Default encoding method."""
+        if isinstance(obj, datetime):
+            return obj.isoformat()
         if isinstance(obj, JSONMixin):
             return obj.encode_for_json()
         return super(JSONTableEncoder, self).default(obj)

--- a/test/pdm/framework/test_Database.py
+++ b/test/pdm/framework/test_Database.py
@@ -65,14 +65,17 @@ class TestDBJson(unittest.TestCase):
     """ Test database JSON methods. """
 
     def test_plain(self):
-        """ Test that JSONTableEncoder works on plain objects.
+        """ Test that JSONTableEncoder works on plain objects,
+            including date-times.
         """
-        test_dict = {'A': 1, 'B': 2}
+        my_time = datetime.datetime.now()
+        test_dict = {'A': 1, 'B': 2, 'C': my_time}
         json_str = json.dumps(test_dict, cls=JSONTableEncoder)
         output_dict = json.loads(json_str)
         self.assertItemsEqual(test_dict.keys(), output_dict.keys())
         self.assertEqual(test_dict['A'], output_dict['A'])
         self.assertEqual(test_dict['B'], output_dict['B'])
+        self.assertEqual(my_time.isoformat(), output_dict['C'])
         # Other objects should fall through to the default,
         # which causes a TypeError
         self.assertRaises(TypeError, json.dumps,


### PR DESCRIPTION
JSONTableEncoder can now encode standalone datetime objects again.

As an aside, I'm not convinced why we would expect the table encoder to do this anyway. The tables will already (as of my other previous new patches) encode their own datetime objects so this will only be useful for standalone datetimes. I can see that there is the convienience of having just a single encoder to maintain and use for all our jsonifying needs but maybe the naming is a bit off then. Or perhaps this should be a separate JSONDatetimeEncoder which you would use as appropriate (This would make using the same `jsonify` function difficult as you would probably have to pass along the encoder to use). 

Anyway we now (with this patch) have the best of both worlds where the tables will be responsible for encoding themselves with a sensible default for datetime objects and we can also use the same encoder (and therefore `jsonify`) to encode standalone datetime objects. I have also reverted the changes to the tests to reflect this.