### PR TITLE
Add CA listing to Site get_endpoint results

### DIFF
--- a/doc/source/reference/api/siteservice.rst
+++ b/doc/source/reference/api/siteservice.rst
@@ -81,8 +81,9 @@ the site.
    Get a list of endpoints for a given site. Generally configured for
    certificate authentication.
 
-   Returns (list of str):
-     Gridftp endpoints for the site in host:port format.
+   Returns dict with keys:
+     - endpoints - List of str, gridftp endpoints host:port format.
+     - cas - (Optional) List of str, PEM encoded CAs for this endpoint.
 
 .. function:: DELETE /user/<user_id(int)>
 

--- a/src/pdm/site/SiteService.py
+++ b/src/pdm/site/SiteService.py
@@ -247,7 +247,16 @@ class SiteService(object):
         endpoints = []
         for ep_info in site.endpoints:
             endpoints.append(ep_info.ep_uri)
-        return jsonify(endpoints)
+        cas = []
+        if site.user_ca_cert:
+            cas.append(site.user_ca_cert)
+        if site.service_ca_cert:
+            cas.append(site.service_ca_cert)
+        # Build response dictionary
+        res = {'endpoints': endpoints}
+        if cas:
+            res['cas'] = cas
+        return jsonify(res)
 
     @staticmethod
     @export_ext("user/<int:user_id>", ["DELETE"])

--- a/test/pdm/site/test_SiteClient.py
+++ b/test/pdm/site/test_SiteClient.py
@@ -67,8 +67,9 @@ class test_SiteClient(unittest.TestCase):
         site_names = [x['site_name'] for x in res]
         self.assertIn("Test Site", site_names)
         # Check the endpoint function
-        eps = self._inst.get_endpoints(site_id)
-        self.assertIsInstance(eps, list)
+        res = self._inst.get_endpoints(site_id)
+        self.assertIsInstance(res, dict)
+        eps = res['endpoints']
         self.assertEqual(len(eps), 2)
         self.assertIn("localhost3:4", eps)
         # Try the delete function

--- a/test/pdm/site/test_SiteService.py
+++ b/test/pdm/site/test_SiteService.py
@@ -203,10 +203,14 @@ class test_SiteService(unittest.TestCase):
         self.__service.fake_auth("CERT", "/CN=Any")
         res = self.__client.get('/site/api/v1.0/endpoint/1')
         self.assertEqual(res.status_code, 200)
-        eps = json.loads(res.data)
+        res = json.loads(res.data)
+        self.assertIsInstance(res, dict)
         # Check we got a list of two endpoints
-        self.assertIsInstance(eps, list)
-        self.assertEqual(len(eps), 2)
+        self.assertIn('endpoints', res)
+        self.assertIsInstance(res['endpoints'], list)
+        self.assertEqual(len(res['endpoints']), 2)
+        self.assertIn('cas', res)
+        self.assertIsInstance(res['cas'], list)
 
     def test_del_user(self):
         """ Test deleting all sites belonging to a given user.


### PR DESCRIPTION
As discussed earlier, this adds a CA list to the function for getting the endpoints, to make the worker coder simpler.