### PR TITLE
Add template_dir option to add_ca_to_dir

### DIFF
--- a/src/pdm/utils/X509.py
+++ b/src/pdm/utils/X509.py
@@ -6,6 +6,7 @@ import os
 import random
 import hashlib
 import tempfile
+from distutils import dir_util
 #pylint: disable=no-member
 from M2Crypto import m2
 from M2Crypto import ASN1, EVP, RSA, X509
@@ -138,7 +139,7 @@ class X509Utils(object):
             pol_fd.write(policy_text)
 
     @staticmethod
-    def add_ca_to_dir(ca_list, dir_path=None):
+    def add_ca_to_dir(ca_list, dir_path=None, template_dir=None):
         """ Adds a CA list to OpenSSL style hash dir.
 
             ca_list - A list of strings, each one a PEM encoded CA certificate
@@ -147,11 +148,18 @@ class X509Utils(object):
                        temporary directory will be created.
                        Note: The caller must delete the directory when they are
                              finished with it to prevent cluttering up /tmp.
+            template_dir - Template directory path (str) to use as the initial
+                           contents of the CA dir if we create it. If dir_path
+                           is not none, then this option is ignored.
+                           Set to None (default) to disable this feature.
             Returns the directory path to the CA dir.
         """
         ca_path = dir_path
         if not ca_path:
             ca_path = tempfile.mkdtemp(prefix='tmpca')
+            if template_dir:
+                dir_util.copy_tree(template_dir, ca_path,
+                                   preserve_symlinks=True)
         for ca_pem in ca_list:
             # Get the OpenSSL hash of the PEM file
             cert = crypto.load_certificate(crypto.FILETYPE_PEM, ca_pem)

--- a/test/pdm/utils/test_X509.py
+++ b/test/pdm/utils/test_X509.py
@@ -179,6 +179,18 @@ class TestX509Utils(unittest.TestCase):
         self.assertRaises(Exception, X509Utils.add_ca_to_dir,
                           [cert_pem], "/mydir")
 
+    @mock.patch("pdm.utils.X509.tempfile")
+    @mock.patch("pdm.utils.X509.dir_util")
+    def test_add_ca_to_dir_template(self, dir_util_mock, temp_mock):
+        """ Test that the add_ca_to_dir template function
+            works as expected.
+        """
+        temp_mock.mkdtemp.return_value = "/new/dir"
+        res = X509Utils.add_ca_to_dir([], template_dir="/my/template")
+        self.assertEqual(res, "/new/dir")
+        dir_util_mock.copy_tree.assert_called_with("/my/template", "/new/dir",
+                                                   preserve_symlinks=True)
+
 class TestX509CA(unittest.TestCase):
     """ Tests of the X509CA module. """
 


### PR DESCRIPTION
Here is the patch to add the option to pre-populate the certificates dir from another directory.

Closes #205.