### PR TITLE
Fix unicode support in X509 policy

### DIFF
--- a/src/pdm/utils/X509.py
+++ b/src/pdm/utils/X509.py
@@ -129,6 +129,8 @@ class X509Utils(object):
 
             Returns None.
         """
+        if isinstance(ca_pem, unicode):
+            ca_pem = ca_pem.encode('ascii','ignore')
         cert = X509.load_cert_string(ca_pem, X509.FORMAT_PEM)
         ca_raw_dn = X509Utils.x509name_to_str(cert.get_subject())
         ca_dn = X509Utils.rfc_to_openssl(ca_raw_dn)


### PR DESCRIPTION
M2Crypto X509 has trouble reading "unicode" strings, but that's what it ends up with when trying to run myproxy-logon. This patch works around this for now (eventually we'll just use pyOpenSSL instead, which doesn't need the fix).