### PR TITLE
Fix WorkqueueService to handle failing list jobs with no listing data.

### DIFF
--- a/src/pdm/workqueue/WorkqueueService.py
+++ b/src/pdm/workqueue/WorkqueueService.py
@@ -137,11 +137,11 @@ class WorkqueueService(object):
         # Update job status.
         JobElement = request.db.tables.JobElement  # pylint: disable=invalid-name
         element = JobElement.query.get_or_404((element_id, job_id))
-        if element.type == JobType.LIST:
+        if element.type == JobType.LIST and request.data['returncode'] == 0:
             require_attrs('listing')
+            element.listing = request.data['listing']
         element.attempts += 1
         element.status = JobStatus.DONE if request.data['returncode'] == 0 else JobStatus.FAILED
-        element.listing = request.data['listing']
         element.update()
 
 #    Job = request.db.tables.Job

--- a/test/pdm/workqueue/test_WorkqueueService.py
+++ b/test/pdm/workqueue/test_WorkqueueService.py
@@ -128,14 +128,13 @@ class TestWorkqueueService(unittest.TestCase):
         self.__service.fake_auth("TOKEN", "1.0")
         request = self.__test.put('/workqueue/api/v1.0/worker/jobs/1/elements/0',
                                   data={'log': 'blah blah',
-                                        'returncode': 1,
+                                        'returncode': 0,
                                         'host': 'somehost.domain'})
         self.assertEqual(request.status_code, 400)
         request = self.__test.put('/workqueue/api/v1.0/worker/jobs/1/elements/0',
                                   data={'log': 'blah blah',
                                         'returncode': 1,
-                                        'host': 'somehost.domain',
-                                        'listing': {'root': []}})
+                                        'host': 'somehost.domain'})
         self.assertEqual(request.status_code, 200)
         Job = self.__service.test_db().tables.Job
         JobElement = self.__service.test_db().tables.JobElement
@@ -174,6 +173,13 @@ class TestWorkqueueService(unittest.TestCase):
         with open(logfile, 'rb') as log:
             self.assertEqual(log.read(), expected_log)
         self.assertEqual(je.listing, {'root': []})
+
+        request = self.__test.put('/workqueue/api/v1.0/worker/jobs/1/elements/0',
+                                  data={'log': 'blah blah',
+                                        'returncode': 0,
+                                        'host': 'somehost.domain',
+                                        'listing': {'root': []}})
+        self.assertEqual(request.status_code, 400, 'Exceeding max tries should give 400')
 
     @mock.patch('pdm.workqueue.WorkqueueService.current_app')
     @mock.patch('pdm.userservicedesk.HRService.HRService.check_token')


### PR DESCRIPTION
This fixes https://github.com/ic-hep/pdm/issues/221
This patch also makes the http error code more explicit in cases where the updating the job element would violate the model constraint of `attempts` <= `max_tries`.