### PR TITLE
Fix proxy overwrite

### DIFF
--- a/src/pdm/site/SiteService.py
+++ b/src/pdm/site/SiteService.py
@@ -377,7 +377,7 @@ class SiteService(object):
         with managed_session(request,
                              message="Database error while storing proxy",
                              http_error_code=500) as session:
-            session.add(new_cred)
+            session.merge(new_cred)
         return ""
 
     @staticmethod


### PR DESCRIPTION
This allows proxies to be overwritten (i.e. so that a user can login to a site a second time to renew their proxy without deleting the old one).

Closes #232.
