### PR TITLE
modified logging so handlers are resolved

### DIFF
--- a/src/pdm/CLI/pdmcli.py
+++ b/src/pdm/CLI/pdmcli.py
@@ -22,7 +22,8 @@ def main(opt_conf_file=None):  #pylint: disable=too-many-branches
     :return: None
     """
 
-    _logger = logging.getLogger(__name__)
+    #_logger = logging.getLogger(__name__)
+    _logger = logging.getLogger()
     _logger.addHandler(logging.StreamHandler())
 
     conf_files = ['~/.pdm/client.conf', '/etc/pdm/client.conf']

--- a/src/pdm/CLI/user_subcommand.py
+++ b/src/pdm/CLI/user_subcommand.py
@@ -532,7 +532,7 @@ class UserCommand(object):
         with open(os.path.expanduser(tokenfile)) as token_file:
             token = token_file.read()
             if not token:
-                print "No token ate requested location. Please login first"
+                print "No token at requested location. Please login first"
             if HRUtils.is_token_expired_insecure(token):
                 print "Token expired. Please log in again"
                 return None


### PR DESCRIPTION
fixes #218 
In addition modify the root logger so, if a token is expired print this:
```
./src/pdm/CLI/pdmcli.py -v -c ../system.client.conf sites
Config file location used: /home/centos/Sisyphos/phase2/system.client.conf
Read config file: /home/centos/Sisyphos/phase2/system.client.conf
Token expired on 2018-05-24T01:41:16.685089
Token expired. Please log in again
```
rather than:

```
Config file location used: /home/centos/Sisyphos/phase2/system.client.conf
No handlers could be found for logger "pdm.userservicedesk.HRUtils"
Token expired. Please log in again
```