### PR TITLE
Ensure cred expiry times are all naive datetimes

### DIFF
--- a/src/pdm/site/SiteService.py
+++ b/src/pdm/site/SiteService.py
@@ -369,10 +369,13 @@ class SiteService(object):
         except Exception as err:
             log.error("Failed to login user: %s", str(err))
             return "Login failed: %s" % str(err), 400
+        # Clear the TZInfo as it should be UTC anyway and the database
+        # uses naive date-time formats.
+        cred_expiry = X509Utils.get_cert_expiry(proxy).replace(tzinfo=None)
         new_cred = Cred(cred_owner=user_id,
                         site_id=site_id,
                         cred_username=username,
-                        cred_expiry=X509Utils.get_cert_expiry(proxy),
+                        cred_expiry=cred_expiry,
                         cred_value=proxy)
         with managed_session(request,
                              message="Database error while storing proxy",


### PR DESCRIPTION
Yes, the test was mocking away the X509Utils function which normally generates a TZ aware datetime, whereas SQLAlchemy with SQLite is always TZ naive. I think the TZ from X509Utils is always GMT anyway, so just dumping the timezone fixes it. I've also updated the test case to trigger the bug, in-case of regressions :-)

Closes #232.