### PR TITLE
Refactor WorkqueueService.get_output.

### DIFF
--- a/src/pdm/workqueue/WorkqueueService.py
+++ b/src/pdm/workqueue/WorkqueueService.py
@@ -313,41 +313,77 @@ class WorkqueueService(object):
     @export_ext('jobs/<int:job_id>/output', ['GET'])
     @export_ext('jobs/<int:job_id>/elements/<int:element_id>/output', ['GET'])
     @export_ext('jobs/<int:job_id>/elements/<int:element_id>/output/<int:attempt>', ['GET'])
-    def get_output(job_id, element_id=0, attempt=None):
+    def get_output(job_id, element_id=None, attempt=None):  # pylint: disable=too-many-branches
         """Get job output."""
-        JobElement = request.db.tables.JobElement  # pylint: disable=invalid-name
-        element = JobElement.query.filter_by(job_id=job_id, id=element_id)\
-                                  .filter(JobElement.status.in_((JobStatus.DONE,
-                                                                 JobStatus.FAILED)))\
-                                  .join(JobElement.job)\
-                                  .filter_by(user_id=HRService.check_token())\
-                                  .first_or_404()
+        Job = request.db.tables.Job  # pylint: disable=invalid-name
+        job = Job.query.filter_by(id=job_id, user_id=HRService.check_token())\
+                       .first_or_404()
 
-        if attempt is None:
+        log_filebase = os.path.join(current_app.workqueueservice_workerlogs,
+                                    job.log_uid[:2],
+                                    job.log_uid)
+
+        if element_id is not None:
+            if element_id not in xrange(len(job.elements)):
+                abort(404, description="Job element %s.%s not found" % (job_id, element_id))
+            element = job.elements[element_id]
+            if element.status not in (JobStatus.DONE, JobStatus.FAILED):
+                abort(400, description="Job element %s.%s not yet ready" % (job_id, element_id))
             if element.attempts == 0:
-                abort(404, description="No attempts have yet been recorded for element %d of "
+                abort(400, description="No attempts have yet been recorded for element %d of "
                                        "job %d. Please try later." % (element_id, job_id))
-            attempt = element.attempts
+            if attempt is None:
+                attempt = element.attempts
+            if attempt not in xrange(1, element.attempts + 1):
+                abort(400, description="Invalid attempt '%s', job.element %s.%s has been tried %s "
+                                       "time(s)" % (attempt, job_id, element_id, element.attempts))
 
-        if attempt not in xrange(1, element.attempts + 1):
-            abort(400, description="Invalid attempt '%s', job has been tried %s time(s)"
-                  % (attempt, element.attempts))
+            log_filename = os.path.join(log_filebase, str(element_id), "attempt%i.log" % attempt)
+            if not os.path.exists(log_filename):
+                abort(500, description="log directory/file %s not found for job.element %s.%s."
+                      % (log_filename, job_id, element_id))
+            with open(log_filename, 'rb') as logfile:
+                log = logfile.read()
 
-        logfilename = os.path.join(current_app.workqueueservice_workerlogs,
-                                   element.job.log_uid[:2],
-                                   element.job.log_uid,
-                                   str(element_id),
-                                   "attempt%i.log" % attempt)
-        if not os.path.exists(logfilename):
-            abort(500, description="log directory/file not found.")
-        with open(logfilename, 'rb') as logfile:
-            log = logfile.read()
+            return_dict = {'jobid': job_id, 'elementid': element_id, 'attempt': attempt,
+                           'type': JobType(element.type).name,  # pylint: disable=no-member
+                           'status': JobStatus(element.status).name,  # pylint: disable=no-member
+                           'log': log}
+            if element.type == JobType.LIST:
+                return_dict.update(listing=element.listing)
+            return jsonify(return_dict)
 
-        return_dict = {'jobid': element.job_id, 'elementid': element.id,
-                       'type': JobType(element.type).name, 'log': log}  # pylint: disable=no-member
-        if element.type == JobType.LIST:
-            return_dict.update(listing=element.listing)
-        return jsonify(return_dict)
+        return_list = []
+        for element in job.elements:
+            if element.status not in (JobStatus.DONE, JobStatus.FAILED):
+                current_app.log.warn("Job element %s.%s not yet ready", job_id, element.id)
+                continue
+            if element.attempts == 0:
+                current_app.log.warn("No attempts have yet been recorded for element %d of "
+                                     "job %d. Please try later.", element.id, job_id)
+                continue
+            if attempt is None:
+                attempt = element.attempts
+            if attempt not in xrange(1, element.attempts + 1):
+                current_app.log.warn("Invalid attempt '%s', job.element %s.%s has been tried %s "
+                                     "time(s)", attempt, job_id, element.id, element.attempts)
+                continue
+
+            log_filename = os.path.join(log_filebase, str(element.id), "attempt%i.log" % attempt)
+            if not os.path.exists(log_filename):
+                abort(500, description="log directory/file %s not found for job.element %s.%s."
+                      % (log_filename, job_id, element.id))
+            with open(log_filename, 'rb') as logfile:
+                log = logfile.read()
+
+            return_dict = {'jobid': job_id, 'elementid': element.id, 'attempt': attempt,
+                           'type': JobType(element.type).name,  # pylint: disable=no-member
+                           'status': JobStatus(element.status).name,  # pylint: disable=no-member
+                           'log': log}
+            if element.type == JobType.LIST:
+                return_dict.update(listing=element.listing)
+            return_list.append(return_dict)
+        return jsonify(return_list)
 
     @staticmethod
     @export_ext("jobs/<int:job_id>/status", ['GET'])

--- a/test/pdm/workqueue/test_WorkqueueService.py
+++ b/test/pdm/workqueue/test_WorkqueueService.py
@@ -468,7 +468,7 @@ class TestWorkqueueService(unittest.TestCase):
 
         mock_hrservice.return_value = 1
         request = self.__test.get('/workqueue/api/v1.0/jobs/1/elements/0/output')
-        self.assertEqual(request.status_code, 404, "Status other than DONE or FAILED gives 404")
+        self.assertEqual(request.status_code, 400, "Status other than DONE or FAILED gives 400")
 
         db = self.__service.test_db()
         session = db.session
@@ -490,7 +490,7 @@ class TestWorkqueueService(unittest.TestCase):
 
         mock_hrservice.return_value = 1
         request = self.__test.get('/workqueue/api/v1.0/jobs/1/elements/0/output')
-        self.assertEqual(request.status_code, 404, "Element with 0 attempts is not yet ready, should give 404")
+        self.assertEqual(request.status_code, 400, "Element with 0 attempts is not yet ready, should give 400")
 
         list_job.elements[0].attempts = 1
         remove_job.elements[0].attempts = 1
@@ -538,35 +538,34 @@ class TestWorkqueueService(unittest.TestCase):
         request = self.__test.get('/workqueue/api/v1.0/jobs/2/output')
         self.assertEqual(request.status_code, 200)
         returned_dict = json.loads(request.data)
-        self.assertEqual(returned_dict, {'jobid': 2, 'elementid': 0, 'type': 'LIST',
-                                         'log': 'blah blah\n', 'listing': {'root': [{'name': 'somefile'}]}})
+        self.assertEqual(returned_dict, [{'status': 'FAILED', 'attempt': 1, 'log': 'blah blah\n', 'jobid': 2, 'listing': {'root': [{'name': 'somefile'}]}, 'type': 'LIST', 'elementid': 0},
+                                         {'status': 'FAILED', 'attempt': 1, 'log': 'tralala\n', 'jobid': 2, 'type': 'REMOVE', 'elementid': 1}])
 
         request = self.__test.get('/workqueue/api/v1.0/jobs/2/elements/0/output')
         self.assertEqual(request.status_code, 200)
         returned_dict = json.loads(request.data)
-        self.assertEqual(returned_dict, {'jobid': 2, 'elementid': 0, 'type': 'LIST',
+        self.assertEqual(returned_dict, {'jobid': 2, 'elementid': 0, 'type': 'LIST', 'attempt': 1, 'status': 'FAILED',
                                          'log': 'blah blah\n', 'listing': {'root': [{'name': 'somefile'}]}})
 
         request = self.__test.get('/workqueue/api/v1.0/jobs/2/elements/0/output/1')
         self.assertEqual(request.status_code, 200)
         returned_dict = json.loads(request.data)
-        self.assertEqual(returned_dict, {'jobid': 2, 'elementid': 0, 'type': 'LIST',
+        self.assertEqual(returned_dict, {'jobid': 2, 'elementid': 0, 'type': 'LIST', 'attempt': 1, 'status': 'FAILED',
                                          'log': 'blah blah\n', 'listing': {'root': [{'name': 'somefile'}]}})
 
         request = self.__test.get('/workqueue/api/v1.0/jobs/2/elements/1/output')
         self.assertEqual(request.status_code, 200)
         returned_dict = json.loads(request.data)
-        self.assertEqual(returned_dict, {'jobid': 2, 'elementid': 1, 'type': 'REMOVE',
-                                         'log': 'tralala\n'})
+        self.assertEqual(returned_dict, {'jobid': 2, 'elementid': 1, 'type': 'REMOVE', 'attempt': 1,
+                                         'status': 'FAILED', 'log': 'tralala\n'})
 
         mock_hrservice.return_value = 1
         request = self.__test.get('/workqueue/api/v1.0/jobs/1/output')
         self.assertEqual(request.status_code, 200)
         returned_dict = json.loads(request.data)
-        self.assertEqual(returned_dict, {'jobid': 1, 'elementid': 0, 'type': 'LIST',
-                                         'log': 'la la la\n',
-                                         'listing': {'root': [{'name': 'somefile'}]}})
+        self.assertEqual(returned_dict, [{'status': 'DONE', 'attempt': 1, 'log': 'la la la\n', 'jobid': 1, 'listing': {'root': [{'name': 'somefile'}]}, 'type': 'LIST', 'elementid': 0}])
 
 ## check jobs in status
 ## check check_token is called
 ## dont hardcode /tmp/workerslogs get it from self.config
+## test_get_output needs more detailed testing.


### PR DESCRIPTION
This commit modifies the get_output function to the following specification as per our recent discussions:

* If no element_id specified get all finished elements.
* If no attempt is specified get latest attempt

main difference is that previously if element_id was omitted only the listing part of the job was returned.