### PR TITLE
Fix to ensure that RENAME jobs have access to dst_endpoints.

### DIFF
--- a/src/pdm/workqueue/Worker.py
+++ b/src/pdm/workqueue/Worker.py
@@ -198,7 +198,7 @@ class Worker(RESTClient, Daemon):  # pylint: disable=too-many-instance-attribute
                         debug=debug)
         conf = getConfig('worker')
         self._types = [JobType[type_.upper()] for type_ in  # pylint: disable=unsubscriptable-object
-                       conf.pop('types', ('LIST', 'COPY', 'REMOVE'))]
+                       conf.pop('types', ('LIST', 'COPY', 'REMOVE', 'MKDIR', 'RENAME'))]
         self._alg = conf.pop('algorithm', 'BY_NUMBER').upper()
         self._alg_args = conf.pop('algorithm.args', {})
         self._interpoll_sleep_time = conf.pop('poll_time', 2)
@@ -286,11 +286,13 @@ class Worker(RESTClient, Daemon):  # pylint: disable=too-many-instance-attribute
                     cas.extend(src_endpoint_dict['cas'])
                     template_ca_dir = None
 
+                if job['type'] in (JobType.COPY, JobType.RENAME):
+                    dst_endpoint_dict = self._site_client.get_endpoints(job['dst_siteid'])
+                    dst_endpoints = dst_endpoint_dict['endpoints']
+
                 if job['type'] == JobType.COPY:
                     credentials.append(job['dst_credentials'])
                     template_ca_dir = self._system_ca_dir
-                    dst_endpoint_dict = self._site_client.get_endpoints(job['dst_siteid'])
-                    dst_endpoints = dst_endpoint_dict['endpoints']
                     if 'cas' in dst_endpoint_dict:
                         cas.extend(dst_endpoint_dict['cas'])
                         template_ca_dir = None

--- a/src/pdm/workqueue/WorkqueueClient.py
+++ b/src/pdm/workqueue/WorkqueueClient.py
@@ -89,7 +89,7 @@ class WorkqueueClient(RESTClient):
                                          'protocol': protocol,
                                          'extra_opts': kwargs})
 
-    def rename(self, src_siteid, src_filepath,  # pylint: disable=too-many-arguments
+    def rename(self, siteid, src_filepath,  # pylint: disable=too-many-arguments
                dst_filepath, max_tries=2, priority=5, protocol=JobProtocol.GRIDFTP, **kwargs):
         """
         Rename a filepath.
@@ -107,9 +107,9 @@ class WorkqueueClient(RESTClient):
         Returns:
             dict: The job object as stored in the workqueue database.
         """
-        return self.post('rename', data={'src_siteid': src_siteid,
+        return self.post('rename', data={'src_siteid': siteid,
                                          'src_filepath': src_filepath,
-                                         'dst_siteid': src_siteid,
+                                         'dst_siteid': siteid,
                                          'dst_filepath': dst_filepath,
                                          'max_tries': max_tries,
                                          'priority':  priority,


### PR DESCRIPTION
this commit also add MKDIR and RENAME jobs to the list of default worker job types and cleans up the WorkqueueClient API