### PR TITLE
Add src to path in Sphinx conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,9 +16,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('./src'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('./src'))
 
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
This will, as the doc says, allow autodoc to document modules.