### PR TITLE
Give site login form fields different names.

### DIFF
--- a/src/pdm/web/WebPageService.py
+++ b/src/pdm/web/WebPageService.py
@@ -165,8 +165,8 @@ class WebPageService(object):
         if site is None:
             abort(404, "Site not found")
 
-        username = request.data.get('username')
-        password = request.data.get('password')
+        username = request.data.get('susername')
+        password = request.data.get('spassword')
         vo_name = request.data.get('vo')
         if username is None:
             abort(400, "username required but missing.")

--- a/src/pdm/web/templates/loginform.html
+++ b/src/pdm/web/templates/loginform.html
@@ -9,7 +9,7 @@
                     <span class="oi oi-person text-primary" aria-hidden="true"></span>
                 </span>
             </div>
-            <input name="username" type="text" value="{{ username }}" class="form-control" placeholder="username" aria-label="Username" aria-describedby="basic-addon1" required>
+            <input name="susername" type="text" value="{{ username }}" class="form-control" placeholder="username" aria-label="Username" aria-describedby="basic-addon1" required>
         </div>
     </div>
 
@@ -21,7 +21,7 @@
                     <span class="oi oi-key text-primary" aria-hidden="true"></span>
                 </span>
             </div>
-            <input name="password" type="password" class="password form-control" placeholder="Password" required>
+            <input name="spassword" type="password" class="password form-control" placeholder="Password" required>
             <div class="input-group-append password_toggle clickable">
                 <span class="input-group-text">
                     <span class="oi oi-eye text-primary" aria-hidden="true"></span>


### PR DESCRIPTION
The idea here is to avoid browsers auto filling them with the main login details.

fixes https://github.com/ic-hep/pdm/issues/330
