### PR TITLE
Fix for double sorting arrows on datatables.

### DIFF
--- a/src/pdm/web/templates/joblist.html
+++ b/src/pdm/web/templates/joblist.html
@@ -1,6 +1,7 @@
 {% extends "dashboard.html" %}
 {% block head %}
-<link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css" />
+<!--conflicts with bootstrap datatables giving two sort arrows and original datatables like table layout -->
+<!--<link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css" />-->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.1/css/bootstrap.css" />
 <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap4.min.css" />
 <style>


### PR DESCRIPTION
This patch also removes the original datatables look which shouldn't be there for the bootstrap theme.

fixes https://github.com/ic-hep/pdm/issues/342
