### PR TITLE
Fix the paths for copying directories.

### DIFF
--- a/src/pdm/web/templates/dashboard.html
+++ b/src/pdm/web/templates/dashboard.html
@@ -209,9 +209,9 @@ function copy(src_site, src_listing, dst_site, dst_listing){
         var is_dir = $(this).children("span.oi").hasClass("oi-folder")
         console.log(`${filename}: is_dir = ${is_dir}`)
         var dst_path = `${dst_root}/${filename}`;
-        if (is_dir){
-            dst_path = dst_root;
-        }
+//        if (is_dir){  // This used to work. Why was this needed then but not now?
+//            dst_path = dst_root;
+//        }
         $.ajax({
             url: "/web/js/copy",
             type: "POST",

--- a/src/pdm/web/templates/joblist.html
+++ b/src/pdm/web/templates/joblist.html
@@ -65,7 +65,7 @@ function preprocess_subtabledata(data, job_id){
         }
         else if(element.status === "SUBMITTED"){
             width = 100 * element.monitoring_info.transferred / Math.floor(element.size/1e6);
-            text = element.monitoring_info.transferred;
+            text = element.monitoring_info.transferred + " Mb";
             colour += "progress-bar-striped progress-bar-animated";
         }
         else{


### PR DESCRIPTION
This fix will enforce that the directory copied ends up at the destination rather than just the content.

The need for this fix confuses me so I have left the code commented out for now. This was definitely working as @martynia and I tested all combinations. It seems that I was passing `src/src_dir` and `dst` to copy but now it needs `src/src_dir` and `dst/dst_dir`.