### PR TITLE
Workqueue copy fix

### DIFF
--- a/src/pdm/workqueue/WorkqueueService.py
+++ b/src/pdm/workqueue/WorkqueueService.py
@@ -1,13 +1,13 @@
 """Workqueue Service."""
 import os
 import stat
-from enum import Enum
 from functools import partial
 from itertools import groupby
 from operator import attrgetter
 from collections import Counter
 from pprint import pformat
 
+from enum import Enum
 from flask import request, abort, current_app
 # from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
@@ -211,7 +211,8 @@ class WorkqueueService(object):
             element_counter = 0
             element_listing = sorted(element.listing.iteritems(), key=lambda item: len(item[0]))
             dir_copy = False
-            if element_listing and element_listing[0][0].rstrip('/') == job.src_filepath.rstrip('/'):
+            if element_listing and \
+                    element_listing[0][0].rstrip('/') == job.src_filepath.rstrip('/'):
                 dir_copy = True
             for root, listing in element_listing:
                 for file_ in listing:
@@ -226,7 +227,7 @@ class WorkqueueService(object):
                         dst_filepath = os.path.join(job.dst_filepath, rel_filepath)
                     job.elements.append(JobElement(id=element_counter,
                                                    src_filepath=src_filepath,
-                                                   dst_filepath=dst_filepath,
+                                                   dst_filepath=os.path.normpath(dst_filepath),
                                                    max_tries=element.max_tries,
                                                    type=job.type,
                                                    size=int(file_["st_size"])))  # int cast needed?

--- a/test/pdm/workqueue/test_WorkqueueService.py
+++ b/test/pdm/workqueue/test_WorkqueueService.py
@@ -295,8 +295,8 @@ class TestWorkqueueService(unittest.TestCase):
         j = Job.query.filter_by(id=7).one()
         self.assertIsNotNone(j)
         self.assertEqual(len(j.elements), 3)
-        self.assertEqual(j.elements[1].dst_filepath, '/site2/data/somedir/data/somefile')
-        self.assertEqual(j.elements[2].dst_filepath, '/site2/data/somedir/data/someotherdir/someotherfile')
+        self.assertEqual(j.elements[1].dst_filepath, '/site2/data/somedir/somefile')
+        self.assertEqual(j.elements[2].dst_filepath, '/site2/data/somedir/someotherdir/someotherfile')
 
         self.__service.fake_auth("TOKEN", "8.0")
         request = self.__test.put('/workqueue/api/v1.0/worker/jobs/8/elements/0',
@@ -322,8 +322,8 @@ class TestWorkqueueService(unittest.TestCase):
         j = Job.query.filter_by(id=8).one()
         self.assertIsNotNone(j)
         self.assertEqual(len(j.elements), 3)
-        self.assertEqual(j.elements[1].dst_filepath, '~/data/somefile')
-        self.assertEqual(j.elements[2].dst_filepath, '~/data/someotherdir/someotherfile')
+        self.assertEqual(j.elements[1].dst_filepath, '~/somefile')
+        self.assertEqual(j.elements[2].dst_filepath, '~/someotherdir/someotherfile')
 
         # Test expansion of REMOVE jobs
         db.session.add(Job(user_id=3, src_siteid=15, src_filepath='/site1/data', type=JobType.REMOVE))


### PR DESCRIPTION
This fix solves the problem of directory copying into a duplicate top level dir. It also cleans up the code making it easer to read and I hope more robust.