### PR TITLE
fix the printout for empty directories (bug caused by removing '.' an…

### DIFF
--- a/src/pdm/CLI/user_subcommand.py
+++ b/src/pdm/CLI/user_subcommand.py
@@ -446,6 +446,9 @@ class UserCommand(object):
         indent = 4
 
         listing = full_listing[root]
+        if not listing:
+            print "<empty>"
+            return
 
         size_len = len(str(max(d['st_size'] for d in listing)))
         links_len = max(d['st_nlink'] for d in listing)


### PR DESCRIPTION
…d '..'. Empty dirs are now really empty
The problem with the printout was, that the dots where causing the directory to have at least 2 elements (. and ..), thus being non-empty. Now, as we have no dotted dirs anymore, the listing of an empty directory does not not attempt to do any formatting, it just prints a string: <empty> 