### PR TITLE
Fix Timeout logging.

### DIFF
--- a/src/pdm/workqueue/Worker.py
+++ b/src/pdm/workqueue/Worker.py
@@ -162,7 +162,10 @@ class StdOutDispatcher(asyncore.file_dispatcher):
             self._callback('worker/jobs/{job_id}/elements/{element_id}',
                            *element_id.split('.'), token=token, data=data)
         self._tokens.clear()  # will cause readable to close fd on next iteration.
-        self.close()
+        try:
+            self.close()  # fd possibly already closed
+        except OSError:
+            pass
 
     def handle_read(self):
         """Handle read events."""

--- a/src/pdm/workqueue/Worker.py
+++ b/src/pdm/workqueue/Worker.py
@@ -142,7 +142,7 @@ class StdOutDispatcher(asyncore.file_dispatcher):
             return False
         return True
 
-    def force_complete(self, returncode):
+    def force_complete(self, returncode, extra_log=''):
         """Force the return of all outstanding elements with given returncode."""
         data = {'returncode': returncode,
                 'timestamp': datetime.utcnow().isoformat(),
@@ -152,6 +152,9 @@ class StdOutDispatcher(asyncore.file_dispatcher):
             log = self._log_dict.pop(element_id, StringIO())
             log.write(stderr)
             log.write('\n')
+            if extra_log:
+                log.write(extra_log)
+                log.write('\n')
             data.update(log=log.getvalue())
             log.close()
             self._logger.info("Uploading output log for job.element %s "
@@ -159,6 +162,7 @@ class StdOutDispatcher(asyncore.file_dispatcher):
             self._callback('worker/jobs/{job_id}/elements/{element_id}',
                            *element_id.split('.'), token=token, data=data)
         self._tokens.clear()  # will cause readable to close fd on next iteration.
+        self.close()
 
     def handle_read(self):
         """Handle read events."""
@@ -415,6 +419,9 @@ class Worker(RESTClient, Daemon):  # pylint: disable=too-many-instance-attribute
                     kill_timer.cancel()
                     if self._current_process.wait():
                         returncode = self._current_process.returncode
-                        stdout_dispatcher.force_complete(returncode=returncode)
+                        extra_log = ''
+                        if returncode == -9:
+                            extra_log = 'Operation timed out!'
+                        stdout_dispatcher.force_complete(returncode=returncode, extra_log=extra_log)
                         self._logger.error("Job %s failed with return: %s", job['id'], returncode)
                         self._logger.info("Job stderr:\n%s", stderr_dispatcher.buffer)

--- a/src/pdm/workqueue/WorkqueueService.py
+++ b/src/pdm/workqueue/WorkqueueService.py
@@ -200,8 +200,10 @@ class WorkqueueService(object):
         if not os.path.exists(dir_):
             os.makedirs(dir_)
         with open(os.path.join(dir_, 'attempt%i.log' % element.attempts), 'wb') as logfile:
-            logfile.write("Job run on host: %s, timestamp: %s\n" % (request.data['host'],
-                                                                    request.data['timestamp']))
+            logfile.write("Job run on host: %s, returncode: %s, timestamp: %s\n"
+                          % (request.data['host'],
+                             request.data['returncode'],
+                             request.data['timestamp']))
             logfile.write(request.data['log'])
 
         # Expand listing for COPY or REMOVE jobs.
@@ -418,7 +420,7 @@ class WorkqueueService(object):
                 log_filename = os.path.join(element_log_filebase, "attempt%i.log" % attempt)
                 log = "log directory/file %s not found for job.element %s.%s."\
                       % (log_filename, job_id, element.id)
-                if not os.path.exists(log_filename):
+                if os.path.exists(log_filename):
                     with open(log_filename, 'rb') as logfile:
                         log = logfile.read()
                 failed_output.update(log=log)

--- a/test/pdm/workqueue/test_WorkqueueService.py
+++ b/test/pdm/workqueue/test_WorkqueueService.py
@@ -159,7 +159,7 @@ class TestWorkqueueService(unittest.TestCase):
         self.assertTrue(os.path.isfile(logfile))
 
         expected_log = dedent("""
-        Job run on host: somehost.domain, timestamp: timestamp
+        Job run on host: somehost.domain, returncode: 1, timestamp: timestamp
         blah blah
         """).strip()
         with open(logfile, 'rb') as log:
@@ -181,6 +181,10 @@ class TestWorkqueueService(unittest.TestCase):
         self.assertEqual(j.status, JobStatus.DONE)
         logfile = os.path.join('/tmp/workers', j.log_uid[:2], j.log_uid, str(je.id), 'attempt2.log')
         self.assertTrue(os.path.isfile(logfile))
+        expected_log = dedent("""
+        Job run on host: somehost.domain, returncode: 0, timestamp: timestamp
+        blah blah
+        """).strip()
         with open(logfile, 'rb') as log:
             self.assertEqual(log.read(), expected_log)
         self.assertEqual(je.listing, {'root': []})


### PR DESCRIPTION
This patch fixes the failure to output correctly attempts other than the first. It also allows adding extra log information when killing the job through say timeout.