### PR TITLE
Allow cafile to be set to None in config

### DIFF
--- a/etc/system.server.conf
+++ b/etc/system.server.conf
@@ -20,6 +20,7 @@ auth = "system.auth"
 
 [server/web]
 port = 5443
+cafile = None
 class = "pdm.web.WebPageService.WebPageService"
 log = "tmp/webpage.log"
 static = "pdm.web.WebPageService"

--- a/src/pdm/framework/Startup.py
+++ b/src/pdm/framework/Startup.py
@@ -40,7 +40,10 @@ class ExecutableServer(object):
     def __fix_path(self, path):
         """ Convert a relative path to be rooted from the config directory
             of this server.
+            If path is None, return is None.
         """
+        if not path:
+          return None
         return os.path.join(self.__conf_base, path)
 
     @staticmethod


### PR DESCRIPTION
This allows cafile to be set to None and uses this for the web site, which prevents it from requesting a user certificate from the client. Fixes #430.
